### PR TITLE
ISS-152 - Gradle report

### DIFF
--- a/src/main/java/org/jsmart/zerocode/core/domain/reports/ZeroCodeReportProperties.java
+++ b/src/main/java/org/jsmart/zerocode/core/domain/reports/ZeroCodeReportProperties.java
@@ -16,6 +16,6 @@ public interface ZeroCodeReportProperties {
     String DEFAULT_REGRESSION_CATEGORY = "Regression";
     String LINK_LABEL_NAME = "Spike Chart(Click here)";
     String ZEROCODE_JUNIT = "zerocode.junit";
-    String NO_RUN_LISTENER = "no-run-listener";
+    String CHARTS_AND_CSV = "gen-smart-charts-csv-reports";
 
 }

--- a/src/main/java/org/jsmart/zerocode/core/domain/reports/ZeroCodeReportProperties.java
+++ b/src/main/java/org/jsmart/zerocode/core/domain/reports/ZeroCodeReportProperties.java
@@ -15,5 +15,7 @@ public interface ZeroCodeReportProperties {
     String REPORT_DISPLAY_NAME_DEFAULT = "Zerocode Interactive Report";
     String DEFAULT_REGRESSION_CATEGORY = "Regression";
     String LINK_LABEL_NAME = "Spike Chart(Click here)";
+    String ZEROCODE_JUNIT = "zerocode.junit";
+    String NO_RUN_LISTENER = "no-run-listener";
 
 }

--- a/src/main/java/org/jsmart/zerocode/core/engine/listener/ZeroCodeTestReportListener.java
+++ b/src/main/java/org/jsmart/zerocode/core/engine/listener/ZeroCodeTestReportListener.java
@@ -34,7 +34,7 @@ public class ZeroCodeTestReportListener extends RunListener {
     }
 
     @Override
-    public void testRunFinished(Result result) throws Exception {
+    public void testRunFinished(Result result) {
         /*
          * Called when all tests have finished
          */

--- a/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeUnitRunner.java
+++ b/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeUnitRunner.java
@@ -303,7 +303,7 @@ public class ZeroCodeUnitRunner extends BlockJUnit4ClassRunner {
              * - https://github.com/gradle/gradle/issues/842
              * - many more related tickets.
              */
-            LOGGER.info("Bypassed JUnit RunListener. Generating useful reports...");
+            LOGGER.debug("Bypassed JUnit RunListener [as configured by the build tool] to generate useful reports...");
             reportListener.testRunFinished(new Result());
         }
     }

--- a/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeUnitRunner.java
+++ b/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeUnitRunner.java
@@ -17,6 +17,7 @@ import org.jsmart.zerocode.core.utils.SmartUtils;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.internal.runners.model.EachTestNotifier;
 import org.junit.runner.Description;
+import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
@@ -31,7 +32,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.lang.System.getProperty;
 import static org.jsmart.zerocode.core.domain.builders.ZeroCodeExecResultBuilder.newInstance;
+import static org.jsmart.zerocode.core.domain.reports.ZeroCodeReportProperties.NO_RUN_LISTENER;
+import static org.jsmart.zerocode.core.domain.reports.ZeroCodeReportProperties.ZEROCODE_JUNIT;
 import static org.jsmart.zerocode.core.utils.RunnerUtils.getEnvSpecificConfigFile;
 
 public class ZeroCodeUnitRunner extends BlockJUnit4ClassRunner {
@@ -97,8 +101,16 @@ public class ZeroCodeUnitRunner extends BlockJUnit4ClassRunner {
 
     @Override
     public void run(RunNotifier notifier) {
-        notifier.addListener(new ZeroCodeTestReportListener(smartUtils.getMapper(), getInjectedReportGenerator()));
+        ZeroCodeTestReportListener reportListener = new ZeroCodeTestReportListener(smartUtils.getMapper(), getInjectedReportGenerator());
+
+        LOGGER.info("System property " + ZEROCODE_JUNIT + "=" + getProperty(ZEROCODE_JUNIT));
+        if(!NO_RUN_LISTENER.equals(getProperty(ZEROCODE_JUNIT))){
+            notifier.addListener(reportListener);
+        }
+
         super.run(notifier);
+
+        handleNoRunListenerReport(reportListener);
     }
 
     @Override
@@ -276,5 +288,23 @@ public class ZeroCodeUnitRunner extends BlockJUnit4ClassRunner {
                 .step(description.getMethodName());
         LOGGER.info("JUnit *requestTimeStamp:{}, \nJUnit Request:{}", timeNow, logPrefixRelationshipId);
         return logPrefixRelationshipId;
+    }
+
+    private void handleNoRunListenerReport(ZeroCodeTestReportListener reportListener) {
+        if(NO_RUN_LISTENER.equals(getProperty(ZEROCODE_JUNIT))){
+            /**
+             * Gradle does not support JUnit RunListener. Hence Zerocode gracefully handled this
+             * upon request from Gradle users. But this is not limited to Gradle, anywhere you
+             * want to bypass the JUnit RunListener, you can achieve this way.
+             * See README for details.
+             *
+             * There are number of tickets opened for this, but not yet fixed.
+             * - https://discuss.gradle.org/t/testrunfinished-not-run-in-junit-integration/14644
+             * - https://github.com/gradle/gradle/issues/842
+             * - many more related tickets.
+             */
+            LOGGER.info("Bypassed JUnit RunListener. Generating useful reports...");
+            reportListener.testRunFinished(new Result());
+        }
     }
 }

--- a/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeUnitRunner.java
+++ b/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeUnitRunner.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.System.getProperty;
 import static org.jsmart.zerocode.core.domain.builders.ZeroCodeExecResultBuilder.newInstance;
-import static org.jsmart.zerocode.core.domain.reports.ZeroCodeReportProperties.NO_RUN_LISTENER;
+import static org.jsmart.zerocode.core.domain.reports.ZeroCodeReportProperties.CHARTS_AND_CSV;
 import static org.jsmart.zerocode.core.domain.reports.ZeroCodeReportProperties.ZEROCODE_JUNIT;
 import static org.jsmart.zerocode.core.utils.RunnerUtils.getEnvSpecificConfigFile;
 
@@ -104,7 +104,7 @@ public class ZeroCodeUnitRunner extends BlockJUnit4ClassRunner {
         ZeroCodeTestReportListener reportListener = new ZeroCodeTestReportListener(smartUtils.getMapper(), getInjectedReportGenerator());
 
         LOGGER.info("System property " + ZEROCODE_JUNIT + "=" + getProperty(ZEROCODE_JUNIT));
-        if(!NO_RUN_LISTENER.equals(getProperty(ZEROCODE_JUNIT))){
+        if(!CHARTS_AND_CSV.equals(getProperty(ZEROCODE_JUNIT))){
             notifier.addListener(reportListener);
         }
 
@@ -291,7 +291,7 @@ public class ZeroCodeUnitRunner extends BlockJUnit4ClassRunner {
     }
 
     private void handleNoRunListenerReport(ZeroCodeTestReportListener reportListener) {
-        if(NO_RUN_LISTENER.equals(getProperty(ZEROCODE_JUNIT))){
+        if(CHARTS_AND_CSV.equals(getProperty(ZEROCODE_JUNIT))){
             /**
              * Gradle does not support JUnit RunListener. Hence Zerocode gracefully handled this
              * upon request from Gradle users. But this is not limited to Gradle, anywhere you


### PR DESCRIPTION
Gradle issues-
- There are number of tickets opened for this, but not yet fixed.
             * - https://discuss.gradle.org/t/testrunfinished-not-run-in-junit-integration/14644
             * - https://github.com/gradle/gradle/issues/842
             * - many more related tickets.

Gradle does not deal with JUnit listeners.
This PR is to bypass listener and generate reports.
_The usual JUnit xml report is still generated at the usual folder._
But Zerocode extent reports are useful and handy for step recognition and search and filter operation, as well as Chart,CSV format and more...
Hence this fix.

Requested by @BeTheCodeWithYou
