### PR TITLE
ISS-241 # Display assumed payload and assertions on step error

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
@@ -243,7 +243,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
                         if (!failureResults.isEmpty()) {
                             StringBuilder builder = new StringBuilder();
                             
-                            // JNEATE 21-05-2019 - Print expected Payload along with assertion errors
+                            // Print expected Payload along with assertion errors
                             builder.append("Assumed Payload: \n" + prettyPrintJson(resolvedAssertionJson) + "\n");
                             builder.append("Assertion Errors: \n");
                             

--- a/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
@@ -242,6 +242,11 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
 
                         if (!failureResults.isEmpty()) {
                             StringBuilder builder = new StringBuilder();
+                            
+                            // JNEATE 21-05-2019 - Print expected Payload along with assertion errors
+                            builder.append("Assumed Payload: \n" + prettyPrintJson(resolvedAssertionJson) + "\n");
+                            builder.append("Assertion Errors: \n");
+                            
                             failureResults.forEach(f -> {
                                 builder.append(f.toString() + "\n");
                             });

--- a/core/src/test/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunner_FailedAssertions.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunner_FailedAssertions.java
@@ -1,0 +1,73 @@
+package org.jsmart.zerocode.core.runner;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.jsmart.zerocode.core.domain.reports.ZeroCodeReportProperties.TARGET_REPORT_DIR;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
+import org.jsmart.zerocode.core.domain.reports.ZeroCodeReport;
+import org.jsmart.zerocode.core.runner.e2e.FailSimpleAssertionInMultiStep;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ZeroCodeMultiStepsScenarioRunner_FailedAssertions {
+	
+    public static final String SCENARIO_NAME = "Two Step - One Fail";
+
+    private ObjectMapper mapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void test_FailSimpleAssertionInMultiStep() {
+    	
+        Result result = JUnitCore.runClasses(FailSimpleAssertionInMultiStep.class);
+        assertThat(result.getRunCount(), is(1));
+
+        File[] files = new File(TARGET_REPORT_DIR).listFiles((dir, fileName) -> fileName.endsWith(".json"));
+
+        List<File> relevantReportFiles = Arrays.asList(files).stream()
+                .filter(thisFile -> thisFile.getName().contains(SCENARIO_NAME) )
+                .collect(Collectors.toList());
+
+        assertThat(relevantReportFiles.size(), is(1));
+
+        relevantReportFiles.forEach(this::testStep);
+        
+    }
+
+    private void testStep(File thisFile) {
+        ZeroCodeReport rawJsonReport = null;
+        try {
+            rawJsonReport = mapper.readValue(new File(thisFile.getAbsolutePath()), ZeroCodeReport.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (thisFile.getName().contains(SCENARIO_NAME)) {
+            assertThat(rawJsonReport.getResults().size(), is(1));
+            assertThat(rawJsonReport.getResults().get(0).getSteps().size(), is(2));
+
+            assertThat(rawJsonReport.getResults().get(0).getSteps().get(0).getName(), is("FailedStep"));
+            assertThat(rawJsonReport.getResults().get(0).getSteps().get(0).getResult(), is("FAILED"));
+            assertThat(rawJsonReport.getResults().get(0).getSteps().get(0).getAssertions(), containsString("Assumed Payload"));
+            assertThat(rawJsonReport.getResults().get(0).getSteps().get(0).getAssertions(), containsString("Assertion Errors"));
+            assertThat(rawJsonReport.getResults().get(0).getSteps().get(0).getAssertions(), containsString("Assertion path"));
+
+            assertThat(rawJsonReport.getResults().get(0).getSteps().get(1).getName(), is("PassedStep"));
+            assertThat(rawJsonReport.getResults().get(0).getSteps().get(1).getResult(), is("PASSED"));
+        }
+    }
+
+}
+
+
+

--- a/core/src/test/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunner_FailedAssertionsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunner_FailedAssertionsTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.Result;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class ZeroCodeMultiStepsScenarioRunner_FailedAssertions {
+public class ZeroCodeMultiStepsScenarioRunner_FailedAssertionsTest {
 	
     public static final String SCENARIO_NAME = "Two Step - One Fail";
 

--- a/core/src/test/java/org/jsmart/zerocode/core/runner/e2e/FailSimpleAssertionInMultiStep.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/runner/e2e/FailSimpleAssertionInMultiStep.java
@@ -1,0 +1,19 @@
+package org.jsmart.zerocode.core.runner.e2e;
+
+import org.jsmart.zerocode.core.domain.HostProperties;
+import org.jsmart.zerocode.core.domain.JsonTestCase;
+import org.jsmart.zerocode.core.tests.customrunner.TestOnlyZeroCodeUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@HostProperties(host="http://localhost", port=9998, context = "")
+@RunWith(TestOnlyZeroCodeUnitRunner.class)
+public class FailSimpleAssertionInMultiStep {
+	
+	@Test
+    @JsonTestCase("19_fail_tests/01_two_step_one_fail.json")
+    public void testFailSimpleAssertionInMultiStep_execAll() throws Exception {
+    	
+    }
+	
+}

--- a/core/src/test/resources/19_fail_tests/01_two_step_one_fail.json
+++ b/core/src/test/resources/19_fail_tests/01_two_step_one_fail.json
@@ -1,0 +1,27 @@
+{
+  "scenarioName": "GIVEN Two Step - One Fail THEN Report assertions and payload",
+  "ignoreStepFailures": true,
+  "steps": [
+    {
+      "name": "FailedStep", 
+      "url": "/thisUrlShouldntWork",
+      "operation": "GET",
+      "request": {},
+      "assertions": {
+        "status": 200
+      }
+    },
+    {
+      "name": "PassedStep",
+      "url": "/thisUrlShouldntWork",
+      "operation": "GET",
+      "request": {},
+      "assertions": {
+        "status": 404
+      }
+    }
+
+  ]
+}
+
+


### PR DESCRIPTION
PR to fix #241 - Basic Unit test added to verify assertions section is updated on step failure

The implemented code doesn't alter the "happy" path, behaviour is unchanged and only the payload is displayed.

Images below show example outputs in Console, JSON and HTML report.
![image](https://user-images.githubusercontent.com/14006260/58191137-e5edc300-7cb5-11e9-908b-e82c2a76a39d.png)

![image](https://user-images.githubusercontent.com/14006260/58191175-f69e3900-7cb5-11e9-85e5-9b9a8335a86e.png)

![image](https://user-images.githubusercontent.com/14006260/58191254-13d30780-7cb6-11e9-9696-8cb9119a53cd.png)

![image](https://user-images.githubusercontent.com/14006260/58191271-1c2b4280-7cb6-11e9-99e2-f8bfc4f501d6.png)
