### PR TITLE
ISS-5 # Update datetime after/before assertion token to 'local.datetime'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2247,8 +2247,8 @@ See below both the examples( See this in the hello-world repo in action i.e. the
 | $CONTAINS.STRING:id was cust-001       | Assertion passes if the node response contains string "id was cust-001" | Otherwise fails |
 | $CONTAINS.STRING.IGNORECASE:id WaS CuSt-001       | Assertion passes if the response value contains string "id was cust-001" with case insensitive | Otherwise fails |
 | $MATCHES.STRING:`\\d{4}-\\d{2}-\\d{2}`       | Assertion passes if the response value contains e.g. `"1989-07-09"` matching regex `\\d{4}-\\d{2}-\\d{2}` | Otherwise fails |
-| $DATE.BEFORE:2017-09-14T09:49:34.000Z       | Assertion passes if the actual date is earlier than this date | Otherwise fails |
-| $DATE.AFTER:2016-09-14T09:49:34.000Z       | Assertion passes if the actual date is later than this date | Otherwise fails |
+| $LOCAL.DATETIME.BEFORE:2017-09-14T09:49:34.000Z       | Assertion passes if the actual date is earlier than this date | Otherwise fails |
+| $LOCAL.DATETIME.AFTER:2016-09-14T09:49:34.000Z       | Assertion passes if the actual date is later than this date | Otherwise fails |
 
 #### Assertion Path holders
 

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeJsonTestProcesorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeJsonTestProcesorImpl.java
@@ -59,8 +59,8 @@ public class ZeroCodeJsonTestProcesorImpl implements ZeroCodeJsonTestProcesor {
     public static final String ASSERT_VALUE_NOT_EQUAL_TO_NUMBER = "$NOT.EQ.";
     public static final String ASSERT_VALUE_GREATER_THAN = "$GT.";
     public static final String ASSERT_VALUE_LESSER_THAN = "$LT.";
-    public static final String ASSERT_DATE_AFTER = "$DATE.AFTER:";
-    public static final String ASSERT_DATE_BEFORE = "$DATE.BEFORE:";
+    public static final String ASSERT_LOCAL_DATETIME_AFTER = "$LOCAL.DATETIME.AFTER:";
+    public static final String ASSERT_LOCAL_DATETIME_BEFORE = "$LOCAL.DATETIME.BEFORE:";
     public static final String ASSERT_PATH_VALUE_NODE = "$";
     public static final String RAW_BODY = ".rawBody";
 
@@ -209,11 +209,11 @@ public class ZeroCodeJsonTestProcesorImpl implements ZeroCodeJsonTestProcesor {
                 } else if (value instanceof String && (value.toString()).startsWith(ASSERT_VALUE_LESSER_THAN)) {
                     String expected = ((String) value).substring(ASSERT_VALUE_LESSER_THAN.length());
                     asserter = new FieldHasLesserThanValueAsserter(path, new BigDecimal(expected));
-                } else if (value instanceof String && (value.toString()).startsWith(ASSERT_DATE_AFTER)) {
-                    String expected = ((String) value).substring(ASSERT_DATE_AFTER.length());
+                } else if (value instanceof String && (value.toString()).startsWith(ASSERT_LOCAL_DATETIME_AFTER)) {
+                    String expected = ((String) value).substring(ASSERT_LOCAL_DATETIME_AFTER.length());
                     asserter = new FieldHasDateAfterValueAsserter(path, parseLocalDateTime(expected));
-                }else if (value instanceof String && (value.toString()).startsWith(ASSERT_DATE_BEFORE)) {
-                    String expected = ((String) value).substring(ASSERT_DATE_BEFORE.length());
+                }else if (value instanceof String && (value.toString()).startsWith(ASSERT_LOCAL_DATETIME_BEFORE)) {
+                    String expected = ((String) value).substring(ASSERT_LOCAL_DATETIME_BEFORE.length());
                     asserter = new FieldHasDateBeforeValueAsserter(path, parseLocalDateTime(expected));
                 }
                 else {

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeJsonTestProcesorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeJsonTestProcesorImplTest.java
@@ -721,8 +721,8 @@ public class ZeroCodeJsonTestProcesorImplTest {
         String mockScenarioState = "{}";
 
         final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
-        assertThat(resolvedAssertions, containsString("\"startDateTime\":\"$DATE.BEFORE:2015-09-14T09:49:34.000Z\","));
-        assertThat(resolvedAssertions, containsString("\"endDateTime\":\"$DATE.AFTER:2015-09-14T09:49:34.000Z\""));
+        assertThat(resolvedAssertions, containsString("\"startDateTime\":\"$LOCAL.DATETIME.BEFORE:2015-09-14T09:49:34.000Z\","));
+        assertThat(resolvedAssertions, containsString("\"endDateTime\":\"$LOCAL.DATETIME.AFTER:2015-09-14T09:49:34.000Z\""));
         
         List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
         assertThat(asserters.size(), is(3));
@@ -752,8 +752,8 @@ public class ZeroCodeJsonTestProcesorImplTest {
         String mockScenarioState = "{}";
 
         final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
-        assertThat(resolvedAssertions, containsString("\"startDateTime\":\"$DATE.BEFORE:2016-09-14T09:49:34.000Z\","));
-        assertThat(resolvedAssertions, containsString("\"endDateTime\":\"$DATE.AFTER:2019-09-14T09:49:34.000Z\""));
+        assertThat(resolvedAssertions, containsString("\"startDateTime\":\"$LOCAL.DATETIME.BEFORE:2016-09-14T09:49:34.000Z\","));
+        assertThat(resolvedAssertions, containsString("\"endDateTime\":\"$LOCAL.DATETIME.AFTER:2019-09-14T09:49:34.000Z\""));
         
         List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
         assertThat(asserters.size(), is(3));
@@ -790,7 +790,7 @@ public class ZeroCodeJsonTestProcesorImplTest {
         String mockScenarioState = "{}";
 
         final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
-        assertThat(resolvedAssertions, containsString("\"startDateTime\":\"$DATE.AFTER:2015-09-14T09:49:34.000Z\""));
+        assertThat(resolvedAssertions, containsString("\"startDateTime\":\"$LOCAL.DATETIME.AFTER:2015-09-14T09:49:34.000Z\""));
         
         List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
         assertThat(asserters.size(), is(2));
@@ -823,7 +823,7 @@ public class ZeroCodeJsonTestProcesorImplTest {
         String mockScenarioState = "{}";
 
         final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
-        assertThat(resolvedAssertions, containsString("\"startDateTime\":\"$DATE.BEFORE:2015-09-14T09:49:34.000Z\""));
+        assertThat(resolvedAssertions, containsString("\"startDateTime\":\"$LOCAL.DATETIME.BEFORE:2015-09-14T09:49:34.000Z\""));
         
         List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
         assertThat(asserters.size(), is(2));

--- a/core/src/test/resources/date_after_before/dateAfterBefore_test_both.json
+++ b/core/src/test/resources/date_after_before/dateAfterBefore_test_both.json
@@ -11,8 +11,8 @@
                 "status": 200,
                 "body": {
                 "projectDetails": {
-	                    "startDateTime" : "$DATE.BEFORE:2015-09-14T09:49:34.000Z",
-	                    "endDateTime" : "$DATE.AFTER:2015-09-14T09:49:34.000Z"
+	                    "startDateTime" : "$LOCAL.DATETIME.BEFORE:2015-09-14T09:49:34.000Z",
+	                    "endDateTime" : "$LOCAL.DATETIME.AFTER:2015-09-14T09:49:34.000Z"
                     }
                 }
             }

--- a/core/src/test/resources/date_after_before/dateAfterBefore_test_fail_afterSameDate.json
+++ b/core/src/test/resources/date_after_before/dateAfterBefore_test_fail_afterSameDate.json
@@ -11,7 +11,7 @@
                 "status": 200,
                 "body": {
                 "projectDetails": {
-	                    "startDateTime" : "$DATE.AFTER:2015-09-14T09:49:34.000Z"
+	                    "startDateTime" : "$LOCAL.DATETIME.AFTER:2015-09-14T09:49:34.000Z"
                     }
                 }
             }

--- a/core/src/test/resources/date_after_before/dateAfterBefore_test_fail_beforeSameDate.json
+++ b/core/src/test/resources/date_after_before/dateAfterBefore_test_fail_beforeSameDate.json
@@ -11,7 +11,7 @@
                 "status": 200,
                 "body": {
                 "projectDetails": {
-	                    "startDateTime" : "$DATE.BEFORE:2015-09-14T09:49:34.000Z"
+	                    "startDateTime" : "$LOCAL.DATETIME.BEFORE:2015-09-14T09:49:34.000Z"
                     }
                 }
             }

--- a/core/src/test/resources/date_after_before/dateAfterBefore_test_fail_both.json
+++ b/core/src/test/resources/date_after_before/dateAfterBefore_test_fail_both.json
@@ -11,8 +11,8 @@
                 "status": 200,
                 "body": {
                 "projectDetails": {
-	                    "startDateTime" : "$DATE.BEFORE:2016-09-14T09:49:34.000Z",
-	                    "endDateTime" : "$DATE.AFTER:2019-09-14T09:49:34.000Z"
+	                    "startDateTime" : "$LOCAL.DATETIME.BEFORE:2016-09-14T09:49:34.000Z",
+	                    "endDateTime" : "$LOCAL.DATETIME.AFTER:2019-09-14T09:49:34.000Z"
                     }
                 }
             }

--- a/http-testing/src/test/resources/helloworld_date/hello_world_date_after_before_test.json
+++ b/http-testing/src/test/resources/helloworld_date/hello_world_date_after_before_test.json
@@ -10,8 +10,8 @@
             "assertions": {
                 "status": 200,
                 "body": {
-                    "created_at" : "$DATE.BEFORE:2015-09-14T09:49:34.000Z",
-                    "updated_at" : "$DATE.AFTER:2015-09-14T09:49:34.000Z"
+                    "created_at" : "$LOCAL.DATETIME.BEFORE:2015-09-14T09:49:34.000Z",
+                    "updated_at" : "$LOCAL.DATETIME.AFTER:2015-09-14T09:49:34.000Z"
                 }
             }
         }


### PR DESCRIPTION
Update assertion tokens '$DATE.BEFORE' and '$DATE.AFTER' introduced in issue #5 to be more specific and uniform with the rest of the project. 

$DATE.BEFORE    ->     $LOCAL.DATETIME.BEFORE
$DATE.AFTER       ->     $LOCAL.DATETIME.AFTER