### PR TITLE
ISS-67 # Add '$ONE.OF:' functionality 

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/FieldIsOneOfValueAsserter.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/FieldIsOneOfValueAsserter.java
@@ -1,0 +1,62 @@
+package org.jsmart.zerocode.core.engine.assertion;
+
+import java.util.Arrays;
+
+public class FieldIsOneOfValueAsserter implements JsonAsserter {
+	private final String path;
+	final Object expected;
+
+	@Override
+	public String getPath() {
+		return path;
+	}
+
+	@Override
+	public AssertionReport actualEqualsToExpected(Object actualResult) {
+		boolean areEqual;
+
+		if (expected != null) {
+			String expectedString = (String) expected;
+
+			// Remove json string array brackets
+			if (expectedString.startsWith("["))
+				expectedString = expectedString.substring(1);
+
+			if (expectedString.endsWith("]"))
+				expectedString = expectedString.substring(0, expectedString.length() - 1);
+
+			// Split into an array
+			final String[] expectedArray = expectedString.split(",");
+
+			// Remove leading and trailing spaces
+			for (int i = 0; i < expectedArray.length; i++) {
+				// If it's just a leading/trailing space and not a whole blank string
+				if (!expectedArray[i].isBlank())
+					expectedArray[i] = expectedArray[i].trim();
+			}
+
+			if (actualResult != null) {
+				// Search list for value
+				areEqual = Arrays.asList(expectedArray).contains(actualResult);
+			} else {
+				areEqual = false;
+			}
+		} else {
+			// Both null
+			if (actualResult == null) {
+				areEqual = true;
+			} else {
+				areEqual = false;
+			}
+		}
+
+		return areEqual ? AssertionReport.createFieldMatchesReport()
+				: AssertionReport.createFieldDoesNotMatchReport(path, "One Of:" + expected, actualResult);
+	}
+
+	public FieldIsOneOfValueAsserter(String path, Object expected) {
+		this.path = path;
+		this.expected = expected;
+	}
+
+}

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/FieldIsOneOfValueAsserter.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/FieldIsOneOfValueAsserter.java
@@ -25,13 +25,22 @@ public class FieldIsOneOfValueAsserter implements JsonAsserter {
 			if (expectedString.endsWith("]"))
 				expectedString = expectedString.substring(0, expectedString.length() - 1);
 
-			// Split into an array
-			final String[] expectedArray = expectedString.split(",");
-
+			// Store collection as a java array
+			String[] expectedArray = null;
+			
+			// Check if it's an empty json array
+			if (!expectedString.isEmpty()) {
+				// Split into an array
+				expectedArray = expectedString.split(",");
+			} else {
+				expectedArray = new String[] {};
+			}
+				
 			// Remove leading and trailing spaces
 			for (int i = 0; i < expectedArray.length; i++) {
-				// If it's just a leading/trailing space and not a whole blank string
-				if (!expectedArray[i].isBlank())
+				// Checking that this is not a whitespace string (cannot use .isBlank() as we're
+				// targeting java 1.8)
+				if (!expectedArray[i].trim().isEmpty())
 					expectedArray[i] = expectedArray[i].trim();
 			}
 

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeJsonTestProcesorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeJsonTestProcesorImpl.java
@@ -61,6 +61,7 @@ public class ZeroCodeJsonTestProcesorImpl implements ZeroCodeJsonTestProcesor {
     public static final String ASSERT_VALUE_LESSER_THAN = "$LT.";
     public static final String ASSERT_LOCAL_DATETIME_AFTER = "$LOCAL.DATETIME.AFTER:";
     public static final String ASSERT_LOCAL_DATETIME_BEFORE = "$LOCAL.DATETIME.BEFORE:";
+    public static final String ASSERT_VALUE_ONE_OF = "$ONE.OF:";
     public static final String ASSERT_PATH_VALUE_NODE = "$";
     public static final String RAW_BODY = ".rawBody";
 
@@ -215,6 +216,9 @@ public class ZeroCodeJsonTestProcesorImpl implements ZeroCodeJsonTestProcesor {
                 }else if (value instanceof String && (value.toString()).startsWith(ASSERT_LOCAL_DATETIME_BEFORE)) {
                     String expected = ((String) value).substring(ASSERT_LOCAL_DATETIME_BEFORE.length());
                     asserter = new FieldHasDateBeforeValueAsserter(path, parseLocalDateTime(expected));
+                }else if (value instanceof String && (value.toString()).startsWith(ASSERT_VALUE_ONE_OF)) {
+                    String expected = ((String) value).substring(ASSERT_VALUE_ONE_OF.length());
+                    asserter = new FieldIsOneOfValueAsserter(path, expected);
                 }
                 else {
                     asserter = new FieldHasExactValueAsserter(path, value);

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeJsonTestProcesorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeJsonTestProcesorImplTest.java
@@ -845,4 +845,165 @@ public class ZeroCodeJsonTestProcesorImplTest {
                 is("Assertion path '$.body.projectDetails.startDateTime' with actual value '2015-09-14T09:49:34.000Z' "
                 		+ "did not match the expected value 'Date Before:2015-09-14T09:49:34'"));
     }
+    
+    @Test
+    public void testValueOneOf_ValuePresent() throws Exception {
+        ScenarioSpec scenarioSpec = smartUtils.jsonFileToJava(
+                "one_of/oneOf_test_currentStatus.json",
+                ScenarioSpec.class);
+
+        final String assertionsSectionAsString = scenarioSpec.getSteps().get(0).getAssertions().toString();
+        String mockScenarioState = "{}";
+
+        final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
+        assertThat(resolvedAssertions, containsString("\"currentStatus\":\"$ONE.OF:[Found, Searching, Not Looking]\""));
+        	
+        	
+        List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
+        assertThat(asserters.size(), is(2));
+
+        String mockTestResponse = "{\n" +
+                "    \"status\": 200,\n" +
+                "    \"body\": {\n" +
+                "        \"currentStatus\": \"Searching\"\n" +
+                "    }\n" +
+                "}";
+        List<AssertionReport> failedReports = jsonPreProcessor.assertAllAndReturnFailed(asserters, mockTestResponse);
+
+        assertThat(failedReports.size(), is(0));
+    }
+    
+    @Test
+    public void testValueOneOf_ValueNotPresent() throws Exception {
+        ScenarioSpec scenarioSpec = smartUtils.jsonFileToJava(
+                "one_of/oneOf_test_currentStatus.json",
+                ScenarioSpec.class);
+
+        final String assertionsSectionAsString = scenarioSpec.getSteps().get(0).getAssertions().toString();
+        String mockScenarioState = "{}";
+
+        final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
+        assertThat(resolvedAssertions, containsString("\"currentStatus\":\"$ONE.OF:[Found, Searching, Not Looking]\""));
+        	
+        	
+        List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
+        assertThat(asserters.size(), is(2));
+
+        String mockTestResponse = "{\n" +
+                "    \"status\": 200,\n" +
+                "    \"body\": {\n" +
+                "        \"currentStatus\": \"Quit\"\n" +
+                "    }\n" +
+                "}";
+        List<AssertionReport> failedReports = jsonPreProcessor.assertAllAndReturnFailed(asserters, mockTestResponse);
+
+        assertThat(failedReports.size(), is(1));
+    }
+    
+    @Test
+    public void testValueOneOf_ActualResultNull() throws Exception {
+        ScenarioSpec scenarioSpec = smartUtils.jsonFileToJava(
+                "one_of/oneOf_test_currentStatus.json",
+                ScenarioSpec.class);
+
+        final String assertionsSectionAsString = scenarioSpec.getSteps().get(0).getAssertions().toString();
+        String mockScenarioState = "{}";
+
+        final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
+        assertThat(resolvedAssertions, containsString("\"currentStatus\":\"$ONE.OF:[Found, Searching, Not Looking]\""));
+        	
+        	
+        List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
+        assertThat(asserters.size(), is(2));
+
+        String mockTestResponse = "{\n" +
+                "    \"status\": 200,\n" +
+                "    \"body\": {\n" +
+                "    }\n" +
+                "}";
+        List<AssertionReport> failedReports = jsonPreProcessor.assertAllAndReturnFailed(asserters, mockTestResponse);
+
+        assertThat(failedReports.size(), is(1));
+    }
+    
+    @Test
+    public void testValueOneOf_MatchEmptyString() throws Exception {
+        ScenarioSpec scenarioSpec = smartUtils.jsonFileToJava(
+                "one_of/oneOf_test_emptyString.json",
+                ScenarioSpec.class);
+
+        final String assertionsSectionAsString = scenarioSpec.getSteps().get(0).getAssertions().toString();
+        String mockScenarioState = "{}";
+
+        final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
+        assertThat(resolvedAssertions, containsString("\"currentStatus\":\"$ONE.OF:[Found, Searching,, Not Looking]\""));
+        	
+        	
+        List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
+        assertThat(asserters.size(), is(2));
+
+        String mockTestResponse = "{\n" +
+                "    \"status\": 200,\n" +
+                "    \"body\": {\n" +
+                "        \"currentStatus\": \"\"\n" +
+                "    }\n" +
+                "}";
+        List<AssertionReport> failedReports = jsonPreProcessor.assertAllAndReturnFailed(asserters, mockTestResponse);
+
+        assertThat(failedReports.size(), is(0));
+    }
+    
+    @Test
+    public void testValueOneOf_MatchWhiteSpace() throws Exception {
+        ScenarioSpec scenarioSpec = smartUtils.jsonFileToJava(
+                "one_of/oneOf_test_whiteSpace.json",
+                ScenarioSpec.class);
+
+        final String assertionsSectionAsString = scenarioSpec.getSteps().get(0).getAssertions().toString();
+        String mockScenarioState = "{}";
+
+        final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
+        assertThat(resolvedAssertions, containsString("\"currentStatus\":\"$ONE.OF:[Found, Searching, , Not Looking]\""));
+        	
+        	
+        List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
+        assertThat(asserters.size(), is(2));
+
+        String mockTestResponse = "{\n" +
+                "    \"status\": 200,\n" +
+                "    \"body\": {\n" +
+                "        \"currentStatus\": \" \"\n" +
+                "    }\n" +
+                "}";
+        List<AssertionReport> failedReports = jsonPreProcessor.assertAllAndReturnFailed(asserters, mockTestResponse);
+
+        assertThat(failedReports.size(), is(0));
+    }
+    
+    @Test
+    public void testValueOneOf_ExpectedArrayEmpty() throws Exception {
+        ScenarioSpec scenarioSpec = smartUtils.jsonFileToJava(
+                "one_of/oneOf_test_expectedArrayEmpty.json",
+                ScenarioSpec.class);
+
+        final String assertionsSectionAsString = scenarioSpec.getSteps().get(0).getAssertions().toString();
+        String mockScenarioState = "{}";
+
+        final String resolvedAssertions = jsonPreProcessor.resolveStringJson(assertionsSectionAsString, mockScenarioState);
+        assertThat(resolvedAssertions, containsString("\"currentStatus\":\"$ONE.OF:[]\""));
+        	
+        	
+        List<JsonAsserter> asserters = jsonPreProcessor.createAssertersFrom(resolvedAssertions);
+        assertThat(asserters.size(), is(2));
+
+        String mockTestResponse = "{\n" +
+                "    \"status\": 200,\n" +
+                "    \"body\": {\n" +
+                "        \"currentStatus\": \"Searching\"\n" +
+                "    }\n" +
+                "}";
+        List<AssertionReport> failedReports = jsonPreProcessor.assertAllAndReturnFailed(asserters, mockTestResponse);
+
+        assertThat(failedReports.size(), is(1));
+    }
 }

--- a/core/src/test/resources/one_of/oneOf_test_currentStatus.json
+++ b/core/src/test/resources/one_of/oneOf_test_currentStatus.json
@@ -1,0 +1,18 @@
+{
+    "scenarioName": "Assert that 'currentStatus' is one of array items",
+    "steps": [
+        {
+            "name": "get_person_job_details",
+            "url": "",
+            "operation": "",
+            "request": {
+            },
+            "assertions": {
+                "status": 200,
+                "body": {
+                	"currentStatus": "$ONE.OF:[Found, Searching, Not Looking]"
+                }
+            }
+        }
+    ]
+}

--- a/core/src/test/resources/one_of/oneOf_test_emptyString.json
+++ b/core/src/test/resources/one_of/oneOf_test_emptyString.json
@@ -1,0 +1,18 @@
+{
+    "scenarioName": "Assert that 'currentStatus' is one of array items, including an empty string",
+    "steps": [
+        {
+            "name": "get_person_job_details",
+            "url": "",
+            "operation": "",
+            "request": {
+            },
+            "assertions": {
+                "status": 200,
+                "body": {
+                	"currentStatus": "$ONE.OF:[Found, Searching,, Not Looking]"
+                }
+            }
+        }
+    ]
+}

--- a/core/src/test/resources/one_of/oneOf_test_expectedArrayEmpty.json
+++ b/core/src/test/resources/one_of/oneOf_test_expectedArrayEmpty.json
@@ -1,0 +1,18 @@
+{
+    "scenarioName": "Assert that 'currentStatus' is one of array items which is empty",
+    "steps": [
+        {
+            "name": "get_person_job_details",
+            "url": "",
+            "operation": "",
+            "request": {
+            },
+            "assertions": {
+                "status": 200,
+                "body": {
+                	"currentStatus": "$ONE.OF:[]"
+                }
+            }
+        }
+    ]
+}

--- a/core/src/test/resources/one_of/oneOf_test_whiteSpace.json
+++ b/core/src/test/resources/one_of/oneOf_test_whiteSpace.json
@@ -1,0 +1,18 @@
+{
+    "scenarioName": "Assert that 'currentStatus' is one of array items, including a whitespace",
+    "steps": [
+        {
+            "name": "get_person_job_details",
+            "url": "",
+            "operation": "",
+            "request": {
+            },
+            "assertions": {
+                "status": 200,
+                "body": {
+                	"currentStatus": "$ONE.OF:[Found, Searching, , Not Looking]"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Added $ONE.OF vanilla case functionality for issue #67 with tests. Empty string values and whitespace values are also supported (for example if actual result is a single whitespace and one of the expected values is a whitespace, the test will pass).

Second PR to fix issue caused by a reference to a Java 11 method in FieldIsOneOfValueAsserter.java (String.isBlank()) in previous PR