### PR TITLE
ISS-248 # Added System Property Token placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2223,7 +2223,7 @@ See below both the examples( See this in the hello-world repo in action i.e. the
 | ${RANDOM.STRING:4}       | Replaces with a random string consists of four english alpphabets | The length can be dynamic |
 | ${STATIC.ALPHABET:5}       | Replaces with abcde ie Static string of length 5| String starts from "a" and continues, repeats after "z"|
 | ${STATIC.ALPHABET:7}       | Replaces with abcdefg ie Static string of length 7| String starts from a"" and continues, repeats after "z"|
-| ${SYSTEM.PROPERTY:java.vendor}       | Replaces with the value of the system property| If no property exists then the place holder remains in place|
+| ${SYSTEM.PROPERTY:java.vendor}       | Replaces with the value of the system property. E.g. `java.vendor` resolves to `Oracle Corporation` or `Azul Systems, Inc.` | If no property exists then the place holder remains in place i.e. `java.vendor` |
 | ${LOCAL.DATE.TODAY:yyyy-MM-dd}       | Resolves this today's date in the format yyyy-MM-dd or any suppliedformat| See format examples here https://github.com/authorjapps/helpme/blob/master/zerocode-rest-help/src/test/resources/tests/00_sample_test_scenarios/18_date_and_datetime_today_generator.json |
 | ${LOCAL.DATETIME.NOW:yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnn}       | Resolves this today's datetime stamp in any supplied format| See format examples here https://github.com/authorjapps/helpme/blob/master/zerocode-rest-help/src/test/resources/tests/00_sample_test_scenarios/18_date_and_datetime_today_generator.json |
 

--- a/README.md
+++ b/README.md
@@ -2223,6 +2223,7 @@ See below both the examples( See this in the hello-world repo in action i.e. the
 | ${RANDOM.STRING:4}       | Replaces with a random string consists of four english alpphabets | The length can be dynamic |
 | ${STATIC.ALPHABET:5}       | Replaces with abcde ie Static string of length 5| String starts from "a" and continues, repeats after "z"|
 | ${STATIC.ALPHABET:7}       | Replaces with abcdefg ie Static string of length 7| String starts from a"" and continues, repeats after "z"|
+| ${SYSTEM.PROPERTY:java.vendor}       | Replaces with the value of the system property| If no property exists then the place holder remains in place|
 | ${LOCAL.DATE.TODAY:yyyy-MM-dd}       | Resolves this today's date in the format yyyy-MM-dd or any suppliedformat| See format examples here https://github.com/authorjapps/helpme/blob/master/zerocode-rest-help/src/test/resources/tests/00_sample_test_scenarios/18_date_and_datetime_today_generator.json |
 | ${LOCAL.DATETIME.NOW:yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnn}       | Resolves this today's datetime stamp in any supplied format| See format examples here https://github.com/authorjapps/helpme/blob/master/zerocode-rest-help/src/test/resources/tests/00_sample_test_scenarios/18_date_and_datetime_today_generator.json |
 

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeTokens.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeTokens.java
@@ -19,6 +19,7 @@ public class ZeroCodeTokens {
     public static final String STATIC_ALPHABET = "STATIC.ALPHABET:";
     public static final String LOCALDATE_TODAY = "LOCAL.DATE.TODAY:";
     public static final String LOCALDATETIME_NOW = "LOCAL.DATETIME.NOW:";
+    public static final String SYSTEM_PROPERTY = "SYSTEM.PROPERTY:";
 
 
     public static List<String> getKnownTokens() {
@@ -29,6 +30,7 @@ public class ZeroCodeTokens {
                 STATIC_ALPHABET,
                 LOCALDATE_TODAY,
                 LOCALDATETIME_NOW,
+                SYSTEM_PROPERTY,
                 XML_FILE,
                 RANDOM_UU_ID,
                 RECORD_DUMP

--- a/core/src/main/java/org/jsmart/zerocode/core/utils/TokenUtils.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/utils/TokenUtils.java
@@ -53,6 +53,11 @@ public class TokenUtils {
                             String formatPattern = runTimeToken.substring(LOCALDATETIME_NOW.length());
                             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(formatPattern);
                             paramaMap.put(runTimeToken, LocalDateTime.now().format(formatter));
+                            
+                        } else if (runTimeToken.startsWith(SYSTEM_PROPERTY)) {
+
+                        	String propertyName = runTimeToken.substring(SYSTEM_PROPERTY.length());
+                        	paramaMap.put(runTimeToken, System.getProperty(propertyName));
 
                         } else if (runTimeToken.startsWith(XML_FILE)) {
                             String xmlFileResource = runTimeToken.substring(XML_FILE.length());

--- a/core/src/test/java/org/jsmart/zerocode/core/utils/TokenUtilsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/utils/TokenUtilsTest.java
@@ -1,5 +1,6 @@
 package org.jsmart.zerocode.core.utils;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -17,18 +18,29 @@ public class TokenUtilsTest {
         assertThat(Long.parseLong(uniqueId) > 1, is(true));
 
     }
-    
+
+    @Ignore("This might fail for who is e.g. Open Jdk or Zulu JDK")
     @Test
-    public void testResolveSystemProperty_PROPERTY_FOUND() {
+    public void testResolveSystemProperty_PROPERTY_FOUND_javaVendor() {
     	
     	String exampleInputString = "zerocode-tokentest: ${SYSTEM.PROPERTY:java.vendor}"; // java.vendor = Oracle Corporation
     	String resolvedString = resolveKnownTokens(exampleInputString);
     	String resolvedToken = resolvedString.substring("zerocode-tokentest: ".length());
     	
     	assertThat(resolvedToken.equals("Oracle Corporation"), is(true));
-    	
+
     }
-    
+
+    @Test
+    public void testResolveSystemProperty_PROPERTY_FOUND_fileEncoing() {
+
+        String exampleInputString = "zerocode-tokentest: ${SYSTEM.PROPERTY:file.encoding}"; // java.vendor = Oracle Corporation
+        String resolvedString = resolveKnownTokens(exampleInputString);
+        String resolvedToken = resolvedString.substring("zerocode-tokentest: ".length());
+
+        assertThat(resolvedToken, is("UTF-8"));
+    }
+
     @Test
     public void testResolveSystemProperty_PROPERTY_NOT_FOUND() {
     	

--- a/core/src/test/java/org/jsmart/zerocode/core/utils/TokenUtilsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/utils/TokenUtilsTest.java
@@ -17,4 +17,26 @@ public class TokenUtilsTest {
         assertThat(Long.parseLong(uniqueId) > 1, is(true));
 
     }
+    
+    @Test
+    public void testResolveSystemProperty_PROPERTY_FOUND() {
+    	
+    	String exampleInputString = "zerocode-tokentest: ${SYSTEM.PROPERTY:java.vendor}"; // java.vendor = Oracle Corporation
+    	String resolvedString = resolveKnownTokens(exampleInputString);
+    	String resolvedToken = resolvedString.substring("zerocode-tokentest: ".length());
+    	
+    	assertThat(resolvedToken.equals("Oracle Corporation"), is(true));
+    	
+    }
+    
+    @Test
+    public void testResolveSystemProperty_PROPERTY_NOT_FOUND() {
+    	
+    	String exampleInputString = "zerocode-tokentest: ${SYSTEM.PROPERTY:dummy_property_one}"; // Property does not exist
+    	String resolvedString = resolveKnownTokens(exampleInputString);
+    	String unResolvedToken = resolvedString.substring("zerocode-tokentest: ".length());
+    	// If the property is NOT FOUND then the token is not resolved and remains as a normal string
+    	assertThat(unResolvedToken.equals("${SYSTEM.PROPERTY:dummy_property_one}"), is(true));
+    	
+    }
 }

--- a/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldtokenresolver/HelloWorldTokenResolverTest.java
+++ b/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldtokenresolver/HelloWorldTokenResolverTest.java
@@ -1,0 +1,19 @@
+package org.jsmart.zerocode.testhelp.tests.helloworldtokenresolver;
+
+import org.jsmart.zerocode.core.domain.JsonTestCase;
+import org.jsmart.zerocode.core.domain.TargetEnv;
+import org.jsmart.zerocode.core.runner.ZeroCodeUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@TargetEnv("github_host.properties")
+@RunWith(ZeroCodeUnitRunner.class)
+public class HelloWorldTokenResolverTest {
+
+    @Test
+    @JsonTestCase("helloworld_token_resolving/helloworld_token_resolving_ok.json")
+    public void testHelloWorldTokenResolving_RESTApi() throws Exception {
+    	
+    }
+
+}

--- a/http-testing/src/test/resources/helloworld_token_resolving/helloworld_token_resolving_ok.json
+++ b/http-testing/src/test/resources/helloworld_token_resolving/helloworld_token_resolving_ok.json
@@ -1,0 +1,29 @@
+{
+    "scenarioName": "GIVEN- the standard token resolving capabilities, WHEN- I invoke GET, THEN- The header tokens will resolve and I will get a 200",
+    "steps": [
+        {
+            "name": "get_user_details",
+            "url": "/users/octocat",
+            "operation": "GET",
+            "request": {
+            	"headers":{
+            		"x-random-number": "${RANDOM.NUMBER}",
+            		"x-random-string-4": "${RANDOM.STRING:4}",
+            		"x-system-property-java-vendor": "${SYSTEM.PROPERTY:java.vendor}",
+            		"x-static-alphabet-6": "${STATIC.ALPHABET:6}",
+            		"x-random-uuid": "${RANDOM.UUID}",
+            		"x-local-date-today": "${LOCAL.DATE.TODAY:yyyy-MM-dd}",
+            		"x-local-datetime-now": "${LOCAL.DATETIME.NOW:yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnn}"
+            	}
+            },
+            "assertions": {
+                "status": 200,
+                "body": {
+                    "login" : "octocat",
+                    "id" : 583231,
+                    "type" : "User"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Fix for #248 

If the property cannot be resolved (Specified property does not exist) then the token is not replaced and remains as a normal string.

For the positive test case I used property `java,vendor` as this should be present on all machines.