### PR TITLE
fix travis ci build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 #specific JDK or multiple JDK can be specified here. There is an issue with mvn surefire and openJDK8. 
 #It is better to switch to openJDK
 language: java
-
+jdk:
+  - oraclejdk8
+  - openjdk8
 
 #This helps to avoid downloading artefacts every time from MVN central. 
 #If you find any CI build failing due to unreflected dependency changes, kindly clear the CI cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 #It is better to switch to openJDK
 language: java
 jdk:
-  - oraclejdk8
   - openjdk8
 
 #This helps to avoid downloading artefacts every time from MVN central. 


### PR DESCRIPTION
Travis has removed the oracle-jdk-8 and defaults to jdk-11 by default which resulted in a build failure.
Due to Oracles new licensing changes oracle-jdk-8 cannot be installed, hence switched to open-jdk-8

REF:
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802
https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038