### PR TITLE
ISSUE-346 # fix content type response with wiremock

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -147,7 +147,7 @@ public class RestEndPointMocker {
         JsonNode headers = mockStep.getResponse().get("headers");
         JsonNode contentType = headers != null ? headers.get("Content-Type") : null;
         responseBuilder = contentType != null ?
-                responseBuilder.withHeader("Content-Type", contentType.toString()).withBody(jsonBodyRequest) :
+                responseBuilder.withHeader("Content-Type", contentType.textValue()).withBody(jsonBodyRequest) :
                 responseBuilder.withBody(jsonBodyRequest);
 
         return responseBuilder;

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMockerTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMockerTest.java
@@ -265,7 +265,7 @@ public class RestEndPointMockerTest {
         JSONAssert.assertEquals(respBody, responseBodyActual, true);
 
         Assert.assertEquals("Content-Type", response.getEntity().getContentType().getName());
-        Assert.assertEquals("\"application/json\"", response.getEntity().getContentType().getValue());
+        Assert.assertEquals("application/json", response.getEntity().getContentType().getValue());
 
         getWireMockServer().stop();
     }

--- a/core/src/test/resources/integration_test_files/wiremock_integration/mock_via_wiremock_then_test_the_end_point.json
+++ b/core/src/test/resources/integration_test_files/wiremock_integration/mock_via_wiremock_then_test_the_end_point.json
@@ -22,6 +22,9 @@
                             "body": {
                                 "id": "cust-007",
                                 "type": "Premium"
+                            },
+                            "headers": {
+                                "Content-Type": "application/json"
                             }
                         }
                     }
@@ -49,6 +52,9 @@
                 "body": {
                     "id": "cust-007",
                     "type": "Premium"
+                },
+                "headers": {
+                    "Content-Type": ["application/json"]
                 }
             }
         },


### PR DESCRIPTION
# Fix Content-Type header on wiremock

## Motivation and Context

Curently, the content-type header is malformed `Content-Type: "application/json"`, it should be `Content-Type: application/json`

close #346