### PR TITLE
Fix typo in example matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ verify:
     addresses:
     - type: Billing
       line1: 10 Random St
-verifyMode: LINIENT
+verifyMode: LENIENT
 ```
 
 or


### PR DESCRIPTION
ISSUE-357 # Fix readme typo (`Lenient` -> `Linient`)

PR Branch
https://github.com/stevenwaterman/zerocode/tree/patch-1

## Motivation and Context

The readme contains a typo. According to the docs at https://github.com/authorjapps/zerocode/wiki#lenient-and-strict-matching, the verification modes are `STRICT` and `LENIENT`, but the first example in the `Matchers` section uses `LINIENT`.

## Checklist:

None relevant
