### PR TITLE
ISSUE-359 # add ability to override properties by by env var

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/di/main/ApplicationMainModule.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/main/ApplicationMainModule.java
@@ -69,7 +69,11 @@ public class ApplicationMainModule extends AbstractModule {
         // ------------------------------------------------
         // Bind properties for localhost, CI, DIT, SIT etc
         // ------------------------------------------------
-        Names.bindProperties(binder(), getProperties(serverEnv));
+        Properties properties = getProperties(serverEnv);
+        properties.putAll(System.getenv());
+        properties.putAll(System.getProperties());
+
+        Names.bindProperties(binder(), properties);
     }
 
     public Properties getProperties(String host) {

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImpl.java
@@ -124,6 +124,7 @@ public class ZeroCodeParameterizedProcessorImpl implements ZeroCodeParameterized
             return objectMapper.readValue(resultantStepJson, ScenarioSpec.class);
 
         } catch (Exception exx) {
+            exx.printStackTrace();
             throw new RuntimeException("Error while resolving parameterizedCsv values - " + exx);
         }
     }

--- a/core/src/test/java/org/jsmart/zerocode/core/di/ApplicationMainModuleTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/di/ApplicationMainModuleTest.java
@@ -21,6 +21,8 @@ public class ApplicationMainModuleTest {
     public static class JukitoModule extends TestModule {
         @Override
         protected void configureTest() {
+            System.getProperties().put("custom_prop_key", "custom_prop_value");
+            System.getProperties().put("key.to.override", "5647");
             ApplicationMainModule applicationMainModule = new ApplicationMainModule("config_hosts_test.properties");
 
             /* Finally install the main module */
@@ -34,6 +36,18 @@ public class ApplicationMainModuleTest {
     @Inject
     @Named("web.application.endpoint.host")
     private String host;
+
+    @Inject
+    @Named("key.to.override")
+    private Integer keyToOverride;
+
+    @Inject
+    @Named("HOME")
+    private String env;
+
+    @Inject
+    @Named("custom_prop_key")
+    private String prop;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -49,4 +63,18 @@ public class ApplicationMainModuleTest {
         assertThat(host, is("http://localhost-test"));
     }
 
+    @Test
+    public void willInject_env_value() throws Exception {
+        assertThat(env, is(System.getenv("HOME")));
+    }
+
+    @Test
+    public void willInject_prop_value() throws Exception {
+        assertThat(prop, is("custom_prop_value"));
+    }
+
+    @Test
+    public void willOverride_properties_by_env_value() throws Exception {
+        assertThat(keyToOverride, is(5647));
+    }
 }

--- a/core/src/test/resources/config_hosts_test.properties
+++ b/core/src/test/resources/config_hosts_test.properties
@@ -4,3 +4,5 @@ web.application.endpoint.port=8820
 
 # Google Map Service Context
 web.application.endpoint.context=/google-map-services
+
+key.to.override=1234


### PR DESCRIPTION
Add ability to override properties by by env var

## Motivation and Context

On our ci we use random port to run application (random port allow to avoid conflict between builds).
To run acceptance tests, we should be able to set configuration using environment var.

close #359 
