### PR TITLE
Issue-383 Make possible to add params on URI and by queryParams simul…

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/httpclient/BasicHttpClient.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/httpclient/BasicHttpClient.java
@@ -1,6 +1,7 @@
 package org.jsmart.zerocode.core.httpclient;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -218,7 +219,7 @@ public class BasicHttpClient {
      * @return : Effective url
      *
      */
-    public String handleUrlAndQueryParams(String httpUrl, Map<String, Object> queryParams) throws IOException {
+    public String handleUrlAndQueryParams(String httpUrl, Map<String, Object> queryParams) throws URISyntaxException {
         if ((queryParams != null) && (!queryParams.isEmpty())) {
             httpUrl = setQueryParams(httpUrl, queryParams);
         }

--- a/core/src/main/java/org/jsmart/zerocode/core/httpclient/utils/UrlQueryParamsUtils.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/httpclient/utils/UrlQueryParamsUtils.java
@@ -1,17 +1,11 @@
 package org.jsmart.zerocode.core.httpclient.utils;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.ArrayList;
+import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Optional.ofNullable;
@@ -19,25 +13,14 @@ import static java.util.Optional.ofNullable;
 public class UrlQueryParamsUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(UrlQueryParamsUtils.class);
 
-    public static String setQueryParams(String httpUrl, Map<String, Object> queryParams) throws IOException {
-        String qualifiedQueryParams = createQualifiedQueryParams(queryParams);
-        httpUrl = httpUrl + "?" + qualifiedQueryParams;
-
-        LOGGER.info("### Effective url is : " + httpUrl);
-        return httpUrl;
+    public static String setQueryParams(final String httpUrl, final Map<String, Object> queryParams) throws URISyntaxException {
+        URIBuilder uriBuilder = new URIBuilder(httpUrl);
+        Map<String, Object> nullSafeQueryParams = ofNullable(queryParams).orElseGet(HashMap::new);
+        nullSafeQueryParams.keySet().forEach(key ->
+                uriBuilder.addParameter(key, nullSafeQueryParams.get(key).toString())
+        );
+        String composedURL = uriBuilder.build().toString();
+        LOGGER.info("### Effective url is : {}", composedURL);
+        return composedURL;
     }
-
-    protected static String createQualifiedQueryParams(Map<String, Object> queryParamsMap) throws IOException {
-        queryParamsMap = ofNullable(queryParamsMap).orElse(new HashMap<>());
-        List<NameValuePair> nameValueList = new ArrayList<>();
-        for(String key : queryParamsMap.keySet()) {
-            nameValueList.add(new BasicNameValuePair(key, queryParamsMap.get(key).toString()));
-        }
-        HttpEntity httpEntity = new UrlEncodedFormEntity(nameValueList);
-        String qualifiedQueryParam = EntityUtils.toString(httpEntity, "UTF-8");
-
-        LOGGER.info("### qualifiedQueryParams : " + qualifiedQueryParam);
-        return qualifiedQueryParam;
-    }
-
 }

--- a/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
@@ -3,6 +3,7 @@ package org.jsmart.zerocode.core.httpclient;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -67,7 +68,7 @@ public class BasicHttpClientTest {
     }
 
     @Test
-    public void test_queryParamEncodedChar() throws IOException {
+    public void test_queryParamEncodedChar() throws URISyntaxException {
         Map<String, Object> queryParamsMap = new HashMap<>();
         queryParamsMap.put("q1", "value1");
         queryParamsMap.put("q2", "value2");
@@ -95,7 +96,7 @@ public class BasicHttpClientTest {
     }
 
     @Test
-    public void test_emptyQueryParams() throws IOException {
+    public void test_emptyQueryParams() throws URISyntaxException {
         String effectiveUrl = basicHttpClient.handleUrlAndQueryParams("http://test-url", new HashMap<>());
         assertThat(effectiveUrl, is("http://test-url"));
         effectiveUrl = basicHttpClient.handleUrlAndQueryParams("http://test-url", null);

--- a/core/src/test/java/org/jsmart/zerocode/core/httpclient/utils/UrlQueryParamsUtilsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/httpclient/utils/UrlQueryParamsUtilsTest.java
@@ -2,7 +2,7 @@ package org.jsmart.zerocode.core.httpclient.utils;
 
 import org.junit.Test;
 
-import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,41 +11,52 @@ import static org.hamcrest.core.Is.is;
 
 public class UrlQueryParamsUtilsTest {
 
+    public static final String BASE_URL = "http://localhost";
+
     @Test
-    public void testNotNull_queryParams() throws IOException {
+    public void testNotNull_queryParams() throws URISyntaxException {
         Map<String, Object> queryParamsMap = new HashMap<>();
         queryParamsMap.put("q1", "value1");
         queryParamsMap.put("q2", 3);
         queryParamsMap.put("q3", 1.9);
 
-        String qualifiedQueryParams = UrlQueryParamsUtils.createQualifiedQueryParams(queryParamsMap);
+        String qualifiedQueryParams = UrlQueryParamsUtils.setQueryParams(BASE_URL, queryParamsMap);
 
-        assertThat(qualifiedQueryParams, is("q1=value1&q2=3&q3=1.9"));
+        assertThat(qualifiedQueryParams, is(BASE_URL + "?q1=value1&q2=3&q3=1.9"));
     }
 
     @Test
-    public void testEmpty_queryParams() throws IOException {
+    public void testEmpty_queryParams() throws URISyntaxException {
         Map<String, Object> queryParamsMap = new HashMap<>();
-        String qualifiedQueryParams = UrlQueryParamsUtils.createQualifiedQueryParams(queryParamsMap);
-        assertThat(qualifiedQueryParams, is(""));
+        String qualifiedQueryParams = UrlQueryParamsUtils.setQueryParams(BASE_URL, queryParamsMap);
+        assertThat(qualifiedQueryParams, is(BASE_URL));
     }
 
     @Test
-    public void testNull_queryParams() throws IOException {
+    public void testNull_queryParams() throws URISyntaxException {
         Map<String, Object> queryParamsMap = null;
-        String qualifiedQueryParams = UrlQueryParamsUtils.createQualifiedQueryParams(queryParamsMap);
-        assertThat(qualifiedQueryParams, is(""));
+        String qualifiedQueryParams = UrlQueryParamsUtils.setQueryParams(BASE_URL, queryParamsMap);
+        assertThat(qualifiedQueryParams, is(BASE_URL));
     }
 
     @Test
-    public void testQueryParams_frontSlash() throws IOException {
+    public void testQueryParams_frontSlash() throws URISyntaxException {
         Map<String, Object> queryParamsMap = new HashMap<>();
         queryParamsMap.put("state/region", "singapore north");
         queryParamsMap.put("q2", "value2");
 
-        String qualifiedQueryParams = UrlQueryParamsUtils.createQualifiedQueryParams(queryParamsMap);
+        String qualifiedQueryParams = UrlQueryParamsUtils.setQueryParams(BASE_URL, queryParamsMap);
 
-        assertThat(qualifiedQueryParams, is("q2=value2&state%2Fregion=singapore+north"));
+        assertThat(qualifiedQueryParams, is(BASE_URL + "?q2=value2&state%2Fregion=singapore+north"));
     }
 
+    @Test
+    public void testQueryParamsCombinedWithUri() throws URISyntaxException {
+        Map<String, Object> queryParamsMap = new HashMap<>();
+        queryParamsMap.put("q2", "2");
+        String uriWithParams = BASE_URL + "?q1=1";
+
+        String qualifiedQueryParams = UrlQueryParamsUtils.setQueryParams(uriWithParams, queryParamsMap);
+        assertThat(qualifiedQueryParams, is(BASE_URL + "?q1=1&q2=2"));
+    }
 }

--- a/core/src/test/resources/integration_test_files/query_params/request_with_query_paramas_map_test.json
+++ b/core/src/test/resources/integration_test_files/query_params/request_with_query_paramas_map_test.json
@@ -34,7 +34,7 @@
             "assertions": {
                 "status": 404,
                 "body": {
-                    "errorId" : "$CONTAINS.STRING:could.not.find.end.point:/api/v1/search/persons?lang=Amazing&city=Lon?lang=Amazing&city=Lon"
+                    "errorId" : "$CONTAINS.STRING:could.not.find.end.point:/api/v1/search/persons?lang=Amazing&city=Lon&lang=Amazing&city=Lon"
                 }
             }
         },
@@ -43,6 +43,25 @@
             "url": "/api/v1/search/persons?lang=Amazing&city=Lon",
             "operation": "GET",
             "request": {
+            },
+            "assertions": {
+                "status": 200,
+                "body" : {
+                    "exactMatches" : true,
+                    "name" : "Mr Bean",
+                    "lang" : "Amazing",
+                    "city" : "Lon"
+                }
+            }
+        },
+        {
+            "name": "find_combing_url_and_query_params",
+            "url": "/api/v1/search/persons?lang=Amazing",
+            "operation": "GET",
+            "request": {
+                "queryParams": {
+                    "city": "Lon"
+                }
             },
             "assertions": {
                 "status": 200,

--- a/http-testing/src/test/resources/helloworld_queryparams/github_get_repos_by_query_params.json
+++ b/http-testing/src/test/resources/helloworld_queryparams/github_get_repos_by_query_params.json
@@ -28,6 +28,20 @@
             }
         },
         {
+            "name": "get_repos_by_query_params",
+            "url": "/users/octocat/repos?page=1",
+            "method": "GET",
+            "request": {
+                "queryParams":{
+                    "per_page":6
+                }
+            },
+            "assertions": {
+                "status": 200,
+                "body.SIZE": 6
+            }
+        },
+        {
             "name": "get_all_reposs_without_query",
             "url": "/users/octocat/repos",
             "method": "GET",


### PR DESCRIPTION
Make possible to add params on URI and by queryParams simultaneously for Http Requests

## Motivation and Context
As software engineer I would like to be possible have query parameter on my URI and on queryParams block.
For that was add apche URIBuilder to handle with query mount, besides what it is probable to resolve future problems situations  

## Checklist:

* [x] Unit tests added?

* [x] Integration tests added?

* [x] Test names are meaningful?

* [x] Feature manually tested?

* [x] Branch build passed?

* [x] No 'package.*' in the imports

* [x] Relevant Wiki page updated with clear instruction for the end user

* [ ] Http test added to `http-testing` module(if applicable) ?

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
