### PR TITLE
Iss 330 send headers while producing to kafka

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/di/provider/GsonSerDeProvider.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/provider/GsonSerDeProvider.java
@@ -1,16 +1,78 @@
 package org.jsmart.zerocode.core.di.provider;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import javax.inject.Provider;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class GsonSerDeProvider implements Provider<Gson> {
 
     @Override
     public Gson get() {
+        return new GsonBuilder()
+                .registerTypeAdapterFactory(KafkaHeadersAdapter.FACTORY)
+                .create();
+    }
 
-        return (new Gson());
+    public static class KafkaHeadersAdapter extends TypeAdapter<Headers> {
+        public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+                if (type.getRawType() == Headers.class) {
+                    return (TypeAdapter<T>) new KafkaHeadersAdapter(gson);
+                }
+                return null;
+            }
+        };
 
+        private Gson gson;
+
+        public KafkaHeadersAdapter(Gson gson) {
+            this.gson = gson;
+        }
+
+        @Override
+        public void write(JsonWriter writer, Headers value) throws IOException {
+            if (value == null || !value.iterator().hasNext()) {
+                writer.nullValue();
+            } else {
+                Map<String, String> headers = new HashMap<>();
+                value.forEach(header -> headers.put(header.key(), new String(header.value())));
+                gson.getAdapter(Map.class).write(writer, headers);
+            }
+        }
+
+        @Override
+        public Headers read(JsonReader reader) throws IOException {
+            Headers headers = null;
+            JsonToken peek = reader.peek();
+            if (JsonToken.NULL.equals(peek)) {
+                reader.nextNull();
+            } else {
+                Map<String, String> map = gson.getAdapter(Map.class).read(reader);
+
+                headers = new RecordHeaders();
+                for (Map.Entry<String, String> entry : map.entrySet()) {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    headers.add(key, value == null ? null : value.getBytes());
+                }
+            }
+
+            return headers;
+        }
     }
 
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/di/provider/GsonSerDeProvider.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/provider/GsonSerDeProvider.java
@@ -25,8 +25,9 @@ public class GsonSerDeProvider implements Provider<Gson> {
                 .create();
     }
 
-    public static class KafkaHeadersAdapter extends TypeAdapter<Headers> {
-        public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
+    static class KafkaHeadersAdapter extends TypeAdapter<Headers> {
+
+        static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
             @SuppressWarnings("unchecked")
             @Override
             public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
@@ -37,7 +38,7 @@ public class GsonSerDeProvider implements Provider<Gson> {
             }
         };
 
-        private Gson gson;
+        private final Gson gson;
 
         public KafkaHeadersAdapter(Gson gson) {
             this.gson = gson;

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelper.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelper.java
@@ -8,15 +8,20 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.jsmart.zerocode.core.di.provider.GsonSerDeProvider;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.jsmart.zerocode.core.kafka.consume.ConsumerLocalConfigs;
@@ -180,11 +185,19 @@ public class KafkaConsumerHelper {
 
             Object key = thisRecord.key();
             Object value = thisRecord.value();
-            LOGGER.info("\nRecord Key - {} , Record value - {}, Record partition - {}, Record offset - {}",
-                    key, value, thisRecord.partition(), thisRecord.offset());
+            Headers headers = thisRecord.headers();
+            LOGGER.info("\nRecord Key - {} , Record value - {}, Record partition - {}, Record offset - {}, Headers - {}",
+                    key, value, thisRecord.partition(), thisRecord.offset(), headers);
 
             JsonNode valueNode = objectMapper.readTree(value.toString());
-            ConsumerJsonRecord jsonRecord = new ConsumerJsonRecord(thisRecord.key(), null, valueNode);
+            Map<String, String> headersMap = null;
+            if (headers != null) {
+                headersMap = new HashMap<>();
+                for (Header header : headers) {
+                    headersMap.put(header.key(), new String(header.value()));
+                }
+            }
+            ConsumerJsonRecord jsonRecord = new ConsumerJsonRecord(thisRecord.key(), null, valueNode, headersMap);
             jsonRecords.add(jsonRecord);
         }
     }

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaProducerHelper.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaProducerHelper.java
@@ -29,7 +29,7 @@ public class KafkaProducerHelper {
     private static final Gson gson = new GsonSerDeProvider().get();
     private static final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
-    public  static Producer<Long, String> createProducer(String bootStrapServers, String producerPropertyFile) {
+    public static Producer<Long, String> createProducer(String bootStrapServers, String producerPropertyFile) {
         try (InputStream propsIs = Resources.getResource(producerPropertyFile).openStream()) {
             Properties properties = new Properties();
             properties.load(propsIs);
@@ -60,18 +60,16 @@ public class KafkaProducerHelper {
                 recordToSend.value());
     }
 
-    public static ProducerRecord prepareJsonRecordToSend(String topicName, ProducerJsonRecord recordToSend) {
-
-        return new ProducerRecord(topicName,
-                //recordToSend.partition(),
-                //recordToSend.timestamp(),
+    public static ProducerRecord<Object, Object> prepareJsonRecordToSend(String topicName, ProducerJsonRecord<?> recordToSend) {
+        return ProducerRecordBuilder.from(topicName,
                 recordToSend.getKey(),
                 // --------------------------------------------
                 // It's a JSON as String. Nothing to worry !
                 // Kafka StringSerializer needs in this format.
                 // --------------------------------------------
-                recordToSend.getValue().toString()
-        );
+                recordToSend.getValue().toString())
+                .withHeaders(recordToSend.getHeaders())
+                .build();
     }
 
 

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaProducerHelper.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaProducerHelper.java
@@ -57,7 +57,8 @@ public class KafkaProducerHelper {
                 recordToSend.partition(),
                 recordToSend.timestamp(),
                 recordToSend.key(),
-                recordToSend.value());
+                recordToSend.value(),
+                recordToSend.headers());
     }
 
     public static ProducerRecord<Object, Object> prepareJsonRecordToSend(String topicName, ProducerJsonRecord<?> recordToSend) {

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/ProducerRecordBuilder.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/ProducerRecordBuilder.java
@@ -1,0 +1,39 @@
+package org.jsmart.zerocode.core.kafka.helper;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+
+import java.util.Map;
+
+public class ProducerRecordBuilder {
+    private String topic;
+    private Object key;
+    private Object value;
+    private Headers headers;
+
+    private ProducerRecordBuilder() {}
+
+    public static ProducerRecordBuilder from(String topic, Object key, Object value) {
+        ProducerRecordBuilder producerRecordBuilder = new ProducerRecordBuilder();
+
+        producerRecordBuilder.topic = topic;
+        producerRecordBuilder.key = key;
+        producerRecordBuilder.value = value;
+
+        return producerRecordBuilder;
+    }
+
+    public ProducerRecordBuilder withHeaders(Map<String, String> headers) {
+        if (headers != null) {
+            this.headers = new RecordHeaders();
+            headers.forEach((hKey, hValue) -> this.headers.add(hKey, hValue.getBytes()));
+        }
+
+        return this;
+    }
+
+    public ProducerRecord<Object, Object> build() {
+        return new ProducerRecord<>(topic, null, null, key, value, headers);
+    }
+}

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecord.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecord.java
@@ -4,19 +4,24 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.util.Map;
+
 public class ConsumerJsonRecord<K> {
     private final K key;
     private final JsonNode jsonKey;
     private final JsonNode value;
+    private final Map<String, String> headers;
 
     @JsonCreator
     public ConsumerJsonRecord(
             @JsonProperty("key") K key,
             @JsonProperty("jsonKey") JsonNode jsonKey,
-            @JsonProperty("value") JsonNode value) {
+            @JsonProperty("value") JsonNode value,
+            @JsonProperty("headers") Map<String, String> headers) {
         this.key = key;
         this.jsonKey = jsonKey;
         this.value = value;
+        this.headers = headers;
     }
 
     public K getKey() {
@@ -29,6 +34,10 @@ public class ConsumerJsonRecord<K> {
 
     public JsonNode getValue() {
         return value;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
     }
 
     @Override

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/send/KafkaSender.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/send/KafkaSender.java
@@ -71,7 +71,7 @@ public class KafkaSender {
                                 LOGGER.info("From file:'{}', Sending record number: {}\n", fileName, i);
                                 deliveryDetails = sendRaw(topicName, producer, record, rawRecords.getAsync());
                             }
-                        } catch(Throwable ex) {
+                        } catch(Exception ex) {
                             throw new RuntimeException(ex);
                         }
                     } else {
@@ -112,7 +112,7 @@ public class KafkaSender {
             }
 
         } catch (Exception e) {
-            LOGGER.error("Error in sending record. Exception : " + e );
+            LOGGER.error("Error in sending record.", e);
             String failedStatus = objectMapper.writeValueAsString(new DeliveryDetails(FAILED, e.getMessage()));
             return prettyPrintJson(failedStatus);
 
@@ -131,7 +131,7 @@ public class KafkaSender {
         ProducerRecord qualifiedRecord = prepareRecordToSend(topicName, recordToSend);
 
         RecordMetadata metadata;
-        if (isAsync != null && isAsync == true) {
+        if (Boolean.TRUE.equals(isAsync)) {
             LOGGER.info("Asynchronous Producer sending record - {}", qualifiedRecord);
             metadata = (RecordMetadata) producer.send(qualifiedRecord, new ProducerAsyncCallback()).get();
         } else {
@@ -157,7 +157,7 @@ public class KafkaSender {
         ProducerRecord record = prepareJsonRecordToSend(topicName, recordToSend);
 
         RecordMetadata metadata;
-        if (isAsync != null && isAsync == true) {
+        if (Boolean.TRUE.equals(isAsync)) {
             LOGGER.info("Asynchronous - Producer sending JSON record - {}", record);
             metadata = (RecordMetadata) producer.send(record, new ProducerAsyncCallback()).get();
         } else {

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/send/KafkaSender.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/send/KafkaSender.java
@@ -61,6 +61,7 @@ public class KafkaSender {
             switch (recordType) {
                 case RAW:
                     rawRecords = gson.fromJson(requestJson, ProducerRawRecords.class);
+
                     String fileName = rawRecords.getFile();
                     if (fileName != null) {
                         File file = validateAndGetFile(fileName);
@@ -71,7 +72,7 @@ public class KafkaSender {
                                 LOGGER.info("From file:'{}', Sending record number: {}\n", fileName, i);
                                 deliveryDetails = sendRaw(topicName, producer, record, rawRecords.getAsync());
                             }
-                        } catch(Exception ex) {
+                        } catch(Throwable ex) {
                             throw new RuntimeException(ex);
                         }
                     } else {
@@ -87,6 +88,7 @@ public class KafkaSender {
 
                 case JSON:
                     jsonRecords = objectMapper.readValue(requestJson, ProducerJsonRecords.class);
+
                     fileName = jsonRecords.getFile();
                     if (fileName != null) {
                         File file = validateAndGetFile(fileName);

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/send/message/ProducerJsonRecord.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/send/message/ProducerJsonRecord.java
@@ -4,20 +4,25 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.util.Map;
+
 // TODO - add timestamp, partition key etc
 public class ProducerJsonRecord<K> {
     private final K key;
     private final JsonNode jsonKey;
     private final JsonNode value;
+    private final Map<String, String> headers;
 
     @JsonCreator
     public ProducerJsonRecord(
             @JsonProperty("key") K key,
             @JsonProperty("jsonKey") JsonNode jsonKey,
-            @JsonProperty("value") JsonNode value) {
+            @JsonProperty("value") JsonNode value,
+            @JsonProperty("headers") Map<String, String> headers) {
         this.key = key;
         this.jsonKey = jsonKey;
         this.value = value;
+        this.headers = headers;
     }
 
     public K getKey() {
@@ -32,12 +37,17 @@ public class ProducerJsonRecord<K> {
         return value;
     }
 
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
     @Override
     public String toString() {
         return "Record{" +
                 "key='" + key + '\'' +
                 ", jsonKey=" + jsonKey +
                 ", value=" + value +
+                ", headers=" + headers +
                 '}';
     }
 }

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelperTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelperTest.java
@@ -1,11 +1,25 @@
 package org.jsmart.zerocode.core.kafka.helper;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Iterators;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.hamcrest.CoreMatchers;
 import org.jsmart.zerocode.core.kafka.consume.ConsumerLocalConfigs;
 import org.jsmart.zerocode.core.kafka.consume.ConsumerLocalConfigsWrap;
 import org.jsmart.zerocode.core.kafka.receive.ConsumerCommonConfigs;
+import org.jsmart.zerocode.core.kafka.receive.message.ConsumerJsonRecord;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -117,5 +131,26 @@ public class KafkaConsumerHelperTest {
 
         assertThat(consumerEffectiveConfigs.getCommitAsync(), is(true));
         assertThat(consumerEffectiveConfigs.getCommitSync(), is(false));
+    }
+
+    @Test
+    public void should_read_json_with_headers_in_record() throws IOException {
+        // given
+        ConsumerRecord consumerRecord = Mockito.mock(ConsumerRecord.class);
+        Mockito.when(consumerRecord.key()).thenReturn("key");
+        Mockito.when(consumerRecord.value()).thenReturn("\"value\"");
+        Mockito.when(consumerRecord.headers())
+                .thenReturn(new RecordHeaders().add("headerKey", "headerValue".getBytes()));
+
+        // when
+        List<ConsumerJsonRecord> consumerJsonRecords = new ArrayList<>();
+        KafkaConsumerHelper.readJson(consumerJsonRecords, Iterators.forArray(consumerRecord));
+
+        // then
+        Assert.assertEquals(1, consumerJsonRecords.size());
+        ConsumerJsonRecord consumerJsonRecord = consumerJsonRecords.get(0);
+        Assert.assertEquals("key", consumerJsonRecord.getKey());
+        Assert.assertEquals("\"value\"", consumerJsonRecord.getValue().toString());
+        Assert.assertEquals(Collections.singletonMap("headerKey", "headerValue"), consumerJsonRecord.getHeaders());
     }
 }

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/ProducerRecordBuilderTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/ProducerRecordBuilderTest.java
@@ -1,0 +1,43 @@
+package org.jsmart.zerocode.core.kafka.helper;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class ProducerRecordBuilderTest {
+
+    @Test
+    public void should_build_producer_record_without_headers() {
+        ProducerRecord<Object, Object> producerRecord = ProducerRecordBuilder
+                .from("topic", "key", "value")
+                .build();
+
+        assertMandatoryProperties(producerRecord);
+    }
+
+    @Test
+    public void should_build_producer_record_with_headers() {
+        ProducerRecord<Object, Object> producerRecord = ProducerRecordBuilder
+                .from("topic", "key", "value")
+                .withHeaders(Collections.singletonMap("headerKey", "headerValue"))
+                .build();
+
+        assertMandatoryProperties(producerRecord);
+        Header[] headers = producerRecord.headers().toArray();
+        assertEquals(1, headers.length);
+        assertEquals("headerKey", headers[0].key());
+        assertThat("headerValue".getBytes(), CoreMatchers.equalTo(headers[0].value()));
+    }
+
+    private void assertMandatoryProperties(ProducerRecord<Object, Object> producerRecord) {
+        assertEquals("topic", producerRecord.topic());
+        assertEquals("key", producerRecord.key());
+        assertEquals("value", producerRecord.value());
+    }
+}

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
@@ -1,11 +1,16 @@
 package org.jsmart.zerocode.core.kafka.receive.message;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -16,24 +21,41 @@ public class ConsumerJsonRecordTest {
 
     @Test
     public void testSer() throws IOException {
+        // TODO: Use assert iso sysout
         String key = "key1";
         JsonNode value = objectMapper.readTree("\"val1\"");
 
-        ConsumerJsonRecord record = new ConsumerJsonRecord(key, null, value);
+        ConsumerJsonRecord<Object> record = new ConsumerJsonRecord<>(key, null, value, null);
         String json = objectMapper.writeValueAsString(record);
         System.out.println("1 json >> " + json);
 
 
         Integer key1 = 123;
-        record = new ConsumerJsonRecord(key1, null, value);
+        record = new ConsumerJsonRecord<>(key1, null, value, null);
         json = objectMapper.writeValueAsString(record);
         System.out.println("1 json >> " + json);
 
 
         Object key2 = 23.45;
-        record = new ConsumerJsonRecord(key2, null, value);
+        record = new ConsumerJsonRecord<>(key2, null, value, null);
         json = objectMapper.writeValueAsString(record);
         System.out.println("2 json >> " + json);
+    }
+
+    @Test
+    public void should_serialize_a_record_with_headers() throws JsonProcessingException {
+        // given
+        JsonNode value = objectMapper.readTree("\"val\"");
+        Map<String, String> headers = new HashMap<>();
+        headers.put("hKey", "hValue");
+        headers.put("hKeyWithNullValue", null);
+        ConsumerJsonRecord<Object> record = new ConsumerJsonRecord<>("123", null, value, headers);
+
+        // when
+        String json = objectMapper.writeValueAsString(record);
+
+        // then
+        assertThat(json, CoreMatchers.equalTo("{\"key\":\"123\",\"jsonKey\":null,\"value\":\"val\",\"headers\":{\"hKey\":\"hValue\",\"hKeyWithNullValue\":null}}"));
     }
 
     @Test

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/send/message/ProducerJsonRecordsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/send/message/ProducerJsonRecordsTest.java
@@ -1,11 +1,15 @@
 package org.jsmart.zerocode.core.kafka.send.message;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
+import org.hamcrest.CoreMatchers;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -48,4 +52,22 @@ public class ProducerJsonRecordsTest {
         assertThat(producerRawRecords.getRecords().get(0).getKey(), is(101));
     }
 
+
+    @Test
+    public void should_read_producer_json_record_with_headers() throws JsonProcessingException {
+        final String json = "{\n" +
+                "                \"key\": 101,\n" +
+                "                \"value\": {\n" +
+                "                   \"name\" : \"Jey\"\n" +
+                "                },\n" +
+                "                \"headers\": {\n" +
+                "                    \"key\": \"value\"\n" +
+                "                }\n" +
+                "            }";
+
+        ProducerJsonRecord producerRawRecord = objectMapper.readValue(json, ProducerJsonRecord.class);
+        Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("key", "value");
+        assertThat(producerRawRecord.getHeaders(), CoreMatchers.equalTo(expectedHeaders));
+    }
 }

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/send/message/ProducerJsonRecordsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/send/message/ProducerJsonRecordsTest.java
@@ -54,7 +54,7 @@ public class ProducerJsonRecordsTest {
 
 
     @Test
-    public void should_read_producer_json_record_with_headers() throws JsonProcessingException {
+    public void testDeser_headers() throws JsonProcessingException {
         final String json = "{\n" +
                 "                \"key\": 101,\n" +
                 "                \"value\": {\n" +

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/send/message/ProducerRawRecordsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/send/message/ProducerRawRecordsTest.java
@@ -4,6 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.jayway.jsonpath.JsonPath;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.jsmart.zerocode.core.di.provider.GsonSerDeProvider;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -46,8 +48,14 @@ public class ProducerRawRecordsTest {
         producerRecord = new ProducerRecord("topic2", "key-123", "{\"name\": \"Nicola\"}");
         jsonBack = gson.toJson(producerRecord);
         assertThat(producerRecord.value(), is("{\"name\": \"Nicola\"}"));
-        JSONAssert.assertEquals("{\"topic\":\"topic2\",\"headers\":{\"headers\":[],\"isReadOnly\":false},\"key\":\"key-123\",\"value\":\"{\\\"name\\\": \\\"Nicola\\\"}\"}", jsonBack, LENIENT);
+        JSONAssert.assertEquals("{\"topic\":\"topic2\",\"key\":\"key-123\",\"value\":\"{\\\"name\\\": \\\"Nicola\\\"}\"}", jsonBack, LENIENT);
 
+        Headers headers = new RecordHeaders();
+        headers.add("headerKey1", "headerValue1".getBytes());
+        headers.add("headerKey2", "headerValue2".getBytes());
+        producerRecord = new ProducerRecord("topic2", null, "key-123", "Hello", headers);
+        jsonBack = gson.toJson(producerRecord);
+        JSONAssert.assertEquals("{\"topic\":\"topic2\",\"headers\":{\"headerKey1\":\"headerValue1\",\"headerKey2\":\"headerValue2\"},\"key\":\"key-123\",\"value\":\"Hello\"}", jsonBack, LENIENT);
     }
 
     @Test

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/send/message/ProducerRawRecordsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/send/message/ProducerRawRecordsTest.java
@@ -49,12 +49,15 @@ public class ProducerRawRecordsTest {
         jsonBack = gson.toJson(producerRecord);
         assertThat(producerRecord.value(), is("{\"name\": \"Nicola\"}"));
         JSONAssert.assertEquals("{\"topic\":\"topic2\",\"key\":\"key-123\",\"value\":\"{\\\"name\\\": \\\"Nicola\\\"}\"}", jsonBack, LENIENT);
+    }
 
+    @Test
+    public void testDeser_headers() {
         Headers headers = new RecordHeaders();
         headers.add("headerKey1", "headerValue1".getBytes());
         headers.add("headerKey2", "headerValue2".getBytes());
-        producerRecord = new ProducerRecord("topic2", null, "key-123", "Hello", headers);
-        jsonBack = gson.toJson(producerRecord);
+        ProducerRecord producerRecord  = new ProducerRecord("topic2", null, "key-123", "Hello", headers);
+        String jsonBack = gson.toJson(producerRecord);
         JSONAssert.assertEquals("{\"topic\":\"topic2\",\"headers\":{\"headerKey1\":\"headerValue1\",\"headerKey2\":\"headerValue2\"},\"key\":\"key-123\",\"value\":\"Hello\"}", jsonBack, LENIENT);
     }
 

--- a/kafka-testing/src/test/java/org/jsmart/zerocode/integration/tests/kafka/KafkaSuite.java
+++ b/kafka-testing/src/test/java/org/jsmart/zerocode/integration/tests/kafka/KafkaSuite.java
@@ -12,9 +12,11 @@ import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceAsyncTest
 import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceIntKeyTest;
 import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceJsonTest;
 import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceRawTest;
+import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceRawWithHeadersTest;
 import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceTest;
 import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceToPartitionTest;
 import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceTwoRecordsTest;
+import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceWithHeadersTest;
 import org.jsmart.zerocode.integration.tests.kafka.produce.KafkaProduceWithTimeStampTest;
 import org.jsmart.zerocode.integration.tests.kafka.produce.file.KafkaProduceAsyncFromFileRawTest;
 import org.jsmart.zerocode.integration.tests.kafka.produce.file.KafkaProduceSyncFromFileJsonTest;
@@ -34,6 +36,8 @@ import org.junit.runners.Suite;
         KafkaProduceTwoRecordsTest.class,
         KafkaProduceRawTest.class,
         KafkaProduceJsonTest.class,
+        KafkaProduceRawWithHeadersTest.class,
+        KafkaProduceWithHeadersTest.class,
         KafkaConsumeRawTest.class,
         KafkaConsumeJsonTest.class,
         KafkaProduceIntKeyTest.class,

--- a/kafka-testing/src/test/java/org/jsmart/zerocode/integration/tests/kafka/produce/KafkaProduceRawWithHeadersTest.java
+++ b/kafka-testing/src/test/java/org/jsmart/zerocode/integration/tests/kafka/produce/KafkaProduceRawWithHeadersTest.java
@@ -1,0 +1,18 @@
+package org.jsmart.zerocode.integration.tests.kafka.produce;
+
+import org.jsmart.zerocode.core.domain.Scenario;
+import org.jsmart.zerocode.core.domain.TargetEnv;
+import org.jsmart.zerocode.core.runner.ZeroCodeUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@TargetEnv("kafka_servers/kafka_test_server_double_key.properties")
+@RunWith(ZeroCodeUnitRunner.class)
+public class KafkaProduceRawWithHeadersTest {
+
+    @Test
+    @Scenario("kafka/produce/test_kafka_produce_raw_with_headers.json")
+    public void should_produce_raw_with_headers() {
+
+    }
+}

--- a/kafka-testing/src/test/java/org/jsmart/zerocode/integration/tests/kafka/produce/KafkaProduceWithHeadersTest.java
+++ b/kafka-testing/src/test/java/org/jsmart/zerocode/integration/tests/kafka/produce/KafkaProduceWithHeadersTest.java
@@ -1,0 +1,18 @@
+package org.jsmart.zerocode.integration.tests.kafka.produce;
+
+import org.jsmart.zerocode.core.domain.Scenario;
+import org.jsmart.zerocode.core.domain.TargetEnv;
+import org.jsmart.zerocode.core.runner.ZeroCodeUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@TargetEnv("kafka_servers/kafka_test_server_int_key.properties")
+@RunWith(ZeroCodeUnitRunner.class)
+public class KafkaProduceWithHeadersTest {
+
+    @Test
+    @Scenario("kafka/produce/test_kafka_produce_json_with_headers.json")
+    public void should_produce_json_with_headers() {
+
+    }
+}

--- a/kafka-testing/src/test/resources/kafka/produce/test_kafka_produce_json_with_headers.json
+++ b/kafka-testing/src/test/resources/kafka/produce/test_kafka_produce_json_with_headers.json
@@ -1,0 +1,56 @@
+{
+  "scenarioName": "Produce a message with headers to a kafka topic",
+  "steps": [
+    {
+      "name": "produce_to_kafka",
+      "url": "kafka-topic:demo-json-headers-topic",
+      "operation": "produce",
+      "request": {
+        "recordType" : "JSON",
+        "records": [
+          {
+            "key": 101,
+            "value": {
+              "name" : "Jey"
+            },
+            "headers": {
+              "hKey": "something",
+              "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+            }
+          }
+        ]
+      },
+      "assertions": {
+        "status": "Ok",
+        "recordMetadata": "$NOT.NULL"
+      }
+    },
+    {
+      "name": "consume_from_kafka",
+      "url": "kafka-topic:demo-json-headers-topic",
+      "operation": "unload",
+      "request": {
+        "consumerLocalConfigs": {
+          "recordType" : "JSON",
+          "commitSync": true,
+          "maxNoOfRetryPollsOrTimeouts": 3
+        }
+      },
+      "assertions": {
+        "size": 1,
+        "records": [
+          {
+            "key": 101,
+            "value": {
+              "name" : "Jey"
+            },
+            "headers": {
+              "hKey": "something",
+              "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kafka-testing/src/test/resources/kafka/produce/test_kafka_produce_json_with_headers.json
+++ b/kafka-testing/src/test/resources/kafka/produce/test_kafka_produce_json_with_headers.json
@@ -1,56 +1,56 @@
 {
-  "scenarioName": "Produce a message with headers to a kafka topic",
-  "steps": [
-    {
-      "name": "produce_to_kafka",
-      "url": "kafka-topic:demo-json-headers-topic",
-      "operation": "produce",
-      "request": {
-        "recordType" : "JSON",
-        "records": [
-          {
-            "key": 101,
-            "value": {
-              "name" : "Jey"
+    "scenarioName": "Produce a message with headers to a kafka topic",
+    "steps": [
+        {
+            "name": "produce_to_kafka",
+            "url": "kafka-topic:demo-json-headers-topic",
+            "operation": "produce",
+            "request": {
+                "recordType": "JSON",
+                "records": [
+                    {
+                        "key": 101,
+                        "value": {
+                            "name": "Jey"
+                        },
+                        "headers": {
+                            "hKey": "something",
+                            "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+                        }
+                    }
+                ]
             },
-            "headers": {
-              "hKey": "something",
-              "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+            "assertions": {
+                "status": "Ok",
+                "recordMetadata": "$NOT.NULL"
             }
-          }
-        ]
-      },
-      "assertions": {
-        "status": "Ok",
-        "recordMetadata": "$NOT.NULL"
-      }
-    },
-    {
-      "name": "consume_from_kafka",
-      "url": "kafka-topic:demo-json-headers-topic",
-      "operation": "unload",
-      "request": {
-        "consumerLocalConfigs": {
-          "recordType" : "JSON",
-          "commitSync": true,
-          "maxNoOfRetryPollsOrTimeouts": 3
+        },
+        {
+            "name": "consume_from_kafka",
+            "url": "kafka-topic:demo-json-headers-topic",
+            "operation": "unload",
+            "request": {
+                "consumerLocalConfigs": {
+                    "recordType": "JSON",
+                    "commitSync": true,
+                    "maxNoOfRetryPollsOrTimeouts": 3
+                }
+            },
+            "assertions": {
+                "size": 1,
+                "records": [
+                    {
+                        "key": 101,
+                        "value": {
+                            "name": "Jey"
+                        },
+                        "headers": {
+                            "hKey": "something",
+                            "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+                        }
+                    }
+                ]
+            }
         }
-      },
-      "assertions": {
-        "size": 1,
-        "records": [
-          {
-            "key": 101,
-            "value": {
-              "name" : "Jey"
-            },
-            "headers": {
-              "hKey": "something",
-              "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
-            }
-          }
-        ]
-      }
-    }
-  ]
+    ]
 }

--- a/kafka-testing/src/test/resources/kafka/produce/test_kafka_produce_raw_with_headers.json
+++ b/kafka-testing/src/test/resources/kafka/produce/test_kafka_produce_raw_with_headers.json
@@ -1,0 +1,52 @@
+{
+  "scenarioName": "Produce a raw message with headers to a kafka topic",
+  "steps": [
+    {
+      "name": "produce_to_kafka",
+      "url": "kafka-topic:demo-raw-headers-topic",
+      "operation": "produce",
+      "request": {
+        "recordType" : "RAW",
+        "records": [
+          {
+            "key": 101,
+            "value": "Something",
+            "headers": {
+              "hKey": "something",
+              "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+            }
+          }
+        ]
+      },
+      "assertions": {
+        "status": "Ok",
+        "recordMetadata": "$NOT.NULL"
+      }
+    },
+    {
+      "name": "consume_from_kafka",
+      "url": "kafka-topic:demo-raw-headers-topic",
+      "operation": "unload",
+      "request": {
+        "consumerLocalConfigs": {
+          "recordType" : "RAW",
+          "commitSync": true,
+          "maxNoOfRetryPollsOrTimeouts": 3
+        }
+      },
+      "assertions": {
+        "size": 1,
+        "records": [
+          {
+            "key": 101,
+            "value": "Something",
+            "headers": {
+              "hKey": "something",
+              "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/kafka-testing/src/test/resources/kafka/produce/test_kafka_produce_raw_with_headers.json
+++ b/kafka-testing/src/test/resources/kafka/produce/test_kafka_produce_raw_with_headers.json
@@ -1,52 +1,52 @@
 {
-  "scenarioName": "Produce a raw message with headers to a kafka topic",
-  "steps": [
-    {
-      "name": "produce_to_kafka",
-      "url": "kafka-topic:demo-raw-headers-topic",
-      "operation": "produce",
-      "request": {
-        "recordType" : "RAW",
-        "records": [
-          {
-            "key": 101,
-            "value": "Something",
-            "headers": {
-              "hKey": "something",
-              "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+    "scenarioName": "Produce a raw message with headers to a kafka topic",
+    "steps": [
+        {
+            "name": "produce_to_kafka",
+            "url": "kafka-topic:demo-raw-headers-topic",
+            "operation": "produce",
+            "request": {
+                "recordType": "RAW",
+                "records": [
+                    {
+                        "key": 101,
+                        "value": "Something",
+                        "headers": {
+                            "hKey": "something",
+                            "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+                        }
+                    }
+                ]
+            },
+            "assertions": {
+                "status": "Ok",
+                "recordMetadata": "$NOT.NULL"
             }
-          }
-        ]
-      },
-      "assertions": {
-        "status": "Ok",
-        "recordMetadata": "$NOT.NULL"
-      }
-    },
-    {
-      "name": "consume_from_kafka",
-      "url": "kafka-topic:demo-raw-headers-topic",
-      "operation": "unload",
-      "request": {
-        "consumerLocalConfigs": {
-          "recordType" : "RAW",
-          "commitSync": true,
-          "maxNoOfRetryPollsOrTimeouts": 3
+        },
+        {
+            "name": "consume_from_kafka",
+            "url": "kafka-topic:demo-raw-headers-topic",
+            "operation": "consume",
+            "request": {
+                "consumerLocalConfigs": {
+                    "recordType": "RAW",
+                    "commitSync": true,
+                    "maxNoOfRetryPollsOrTimeouts": 3
+                }
+            },
+            "assertions": {
+                "size": "$GT.0",
+                "records": [
+                    {
+                        "key": 101,
+                        "value": "Something",
+                        "headers": {
+                            "hKey": "something",
+                            "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
+                        }
+                    }
+                ]
+            }
         }
-      },
-      "assertions": {
-        "size": 1,
-        "records": [
-          {
-            "key": 101,
-            "value": "Something",
-            "headers": {
-              "hKey": "something",
-              "correlationId": "d85e88d2-3247-40a8-9c56-ec29004c45c9"
-            }
-          }
-        ]
-      }
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
# send headers while producing to kafka

PR Branch
https://github.com/Cyril-Edme/zerocode/tree/ISS-330-send-headers-while-producing-to-kafka

## Motivation and Context
We should be able to send some headers in our Kafka message. As well as the consumer should be able to assert on the received headers.

## Checklist:

* [x] Unit tests added

* [x] Integration tests added

* [x] Test names are meaningful

* [x] Feature manually tested

* [x] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [x] Kafka test added to `kafka-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect Kafka automation flow
