### PR TITLE
Fix issue 421 kafka receiver

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelper.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelper.java
@@ -286,9 +286,9 @@ public class KafkaConsumerHelper {
 
     private static void validateSeekConfig(ConsumerLocalConfigs localConfigs) {
         String seek = localConfigs.getSeek();
-        if(!isEmpty(seek)) {
+        if (!isEmpty(seek)) {
             String[] split = seek.split(",");
-            if(split == null || split.length < 3) {
+            if (split == null || split.length < 3) {
                 throw new RuntimeException("\n------> 'seek' should contain 'topic,partition,offset' e.g. 'topic1,0,2' ");
             }
         }

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/receive/KafkaReceiver.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/receive/KafkaReceiver.java
@@ -71,29 +71,26 @@ public class KafkaReceiver {
                 } else {
                     continue;
                 }
-            } else {
-                LOGGER.info("Received {} records after {} timeouts\n", records.count(), noOfTimeOuts);
             }
 
-            if (records != null) {
-                Iterator recordIterator = records.iterator();
+            LOGGER.info("Received {} records after {} timeouts\n", records.count(), noOfTimeOuts);
 
-                LOGGER.info("Consumer chosen recordType: " + effectiveLocal.getRecordType());
+            Iterator recordIterator = records.iterator();
 
-                switch (effectiveLocal.getRecordType()) {
-                    case RAW:
-                        readRaw(rawRecords, recordIterator);
-                        break;
+            LOGGER.info("Consumer chosen recordType: " + effectiveLocal.getRecordType());
 
-                    case JSON:
-                        readJson(jsonRecords, recordIterator);
-                        break;
+            switch (effectiveLocal.getRecordType()) {
+                case RAW:
+                    readRaw(rawRecords, recordIterator);
+                    break;
 
-                    default:
-                        throw new RuntimeException("Unsupported record type - '" + effectiveLocal.getRecordType()
-                                + "'. Supported values are 'JSON','RAW'");
-                }
+                case JSON:
+                    readJson(jsonRecords, recordIterator);
+                    break;
 
+                default:
+                    throw new RuntimeException("Unsupported record type - '" + effectiveLocal.getRecordType()
+                            + "'. Supported values are 'JSON','RAW'");
             }
 
             handleCommitSyncAsync(consumer, consumerCommonConfigs, effectiveLocal);

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/receive/KafkaReceiver.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/receive/KafkaReceiver.java
@@ -1,6 +1,5 @@
 package org.jsmart.zerocode.core.kafka.receive;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -11,7 +10,6 @@ import java.util.List;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.jsmart.zerocode.core.kafka.consume.ConsumerLocalConfigs;
 import org.jsmart.zerocode.core.kafka.receive.message.ConsumerJsonRecord;
 import org.slf4j.Logger;
@@ -36,8 +34,6 @@ import static org.jsmart.zerocode.core.kafka.helper.KafkaFileRecordHelper.handle
 public class KafkaReceiver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaReceiver.class);
-
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
     @Inject(optional = true)
     @Named("kafka.consumer.properties")

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelperTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelperTest.java
@@ -1,7 +1,10 @@
 package org.jsmart.zerocode.core.kafka.helper;
 
 import com.google.common.collect.Iterators;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.jsmart.zerocode.core.kafka.consume.ConsumerLocalConfigs;
 import org.jsmart.zerocode.core.kafka.consume.ConsumerLocalConfigsWrap;
@@ -14,14 +17,19 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.jsmart.zerocode.core.kafka.helper.KafkaConsumerHelper.deriveEffectiveConfigs;
+import static org.jsmart.zerocode.core.kafka.helper.KafkaConsumerHelper.initialPollWaitingForConsumerGroupJoin;
+import static org.mockito.Matchers.any;
 
 public class KafkaConsumerHelperTest {
 
@@ -32,7 +40,7 @@ public class KafkaConsumerHelperTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void test_syncAsyncTrueCommon() throws Exception{
+    public void test_syncAsyncTrueCommon() throws Exception {
         consumerCommon = new ConsumerCommonConfigs(true, true, "aTestFile", "JSON", true, 3, 50L, "");
 
         expectedException.expectMessage("Both commitSync and commitAsync can not be true");
@@ -40,7 +48,7 @@ public class KafkaConsumerHelperTest {
     }
 
     @Test
-    public void test_syncAsyncTrueLocal() throws Exception{
+    public void test_syncAsyncTrueLocal() throws Exception {
         consumerCommon = new ConsumerCommonConfigs(true, false, "aTestFile", "JSON", true, 3, 50L, "");
         consumerLocal = new ConsumerLocalConfigs("RAW", "sTestLocalFile", true, true, false, 3, 50L, "1,0,test-topic");
         ConsumerLocalConfigsWrap localConfigsWrap = new ConsumerLocalConfigsWrap(consumerLocal);
@@ -50,7 +58,7 @@ public class KafkaConsumerHelperTest {
     }
 
     @Test
-    public void test_effectiveConfigsIsLocal() throws Exception{
+    public void test_effectiveConfigsIsLocal() throws Exception {
 
         consumerCommon = new ConsumerCommonConfigs(true, false, "aTestFile", "JSON", true, 3, 50L, "");
         consumerLocal = new ConsumerLocalConfigs("RAW", "sTestLocalFile", true, false, false, 3, 150L, "1,0,test-topic");
@@ -66,7 +74,7 @@ public class KafkaConsumerHelperTest {
     }
 
     @Test
-    public void test_effectiveConfigsIsCentrall() throws Exception{
+    public void test_effectiveConfigsIsCentral() throws Exception {
 
         consumerCommon = new ConsumerCommonConfigs(true, false, "aTestFile", "JSON", true, 3, 50L, "");
         consumerLocal = null;
@@ -81,10 +89,10 @@ public class KafkaConsumerHelperTest {
     }
 
     @Test
-    public void test_effectiveCommitAsync_true() throws Exception{
+    public void test_effectiveCommitAsync_true() throws Exception {
 
         consumerCommon = new ConsumerCommonConfigs(true, null, "aTestFile", "JSON", true, 3, 50L, "");
-        consumerLocal = new ConsumerLocalConfigs("RAW", "sTestLocalFile",  true, false, false, 3, 50L, "1,0,test-topic");
+        consumerLocal = new ConsumerLocalConfigs("RAW", "sTestLocalFile", true, false, false, 3, 50L, "1,0,test-topic");
 
         ConsumerLocalConfigs consumerEffectiveConfigs = deriveEffectiveConfigs(consumerLocal, consumerCommon);
 
@@ -93,7 +101,7 @@ public class KafkaConsumerHelperTest {
     }
 
     @Test
-    public void test_effectiveCommitSync_true() throws Exception{
+    public void test_effectiveCommitSync_true() throws Exception {
 
         consumerCommon = new ConsumerCommonConfigs(null, true, "aTestFile", "JSON", true, 3, 50L, "");
         consumerLocal = new ConsumerLocalConfigs("RAW", "sTestLocalFile", null, true, false, 3, 50L, "1,0,test-topic");
@@ -105,7 +113,7 @@ public class KafkaConsumerHelperTest {
     }
 
     @Test
-    public void test_effectiveCommitSyncFromCommon_true() throws Exception{
+    public void test_effectiveCommitSyncFromCommon_true() throws Exception {
 
         consumerCommon = new ConsumerCommonConfigs(true, false, "aTestFile", "JSON", true, 3, 50L, "");
         consumerLocal = new ConsumerLocalConfigs("RAW", "sTestLocalFile", null, null, false, 3, 50L, "1,0,test-topic");
@@ -117,9 +125,9 @@ public class KafkaConsumerHelperTest {
     }
 
     @Test
-    public void test_effectiveCommitAsyncFromCommon_true() throws Exception{
+    public void test_effectiveCommitAsyncFromCommon_true() throws Exception {
 
-        consumerCommon = new ConsumerCommonConfigs(null, true, "aTestFile", "JSON", true, 3,50L, "");
+        consumerCommon = new ConsumerCommonConfigs(null, true, "aTestFile", "JSON", true, 3, 50L, "");
         consumerLocal = new ConsumerLocalConfigs("RAW", "sTestLocalFile", true, false, false, 3, 150L, "1,0,test-topic");
 
         ConsumerLocalConfigs consumerEffectiveConfigs = deriveEffectiveConfigs(consumerLocal, consumerCommon);
@@ -147,5 +155,57 @@ public class KafkaConsumerHelperTest {
         Assert.assertEquals("key", consumerJsonRecord.getKey());
         Assert.assertEquals("\"value\"", consumerJsonRecord.getValue().toString());
         Assert.assertEquals(Collections.singletonMap("headerKey", "headerValue"), consumerJsonRecord.getHeaders());
+    }
+
+    @Test
+    public void test_firstPoll_exits_early_on_assignment() {
+        // given
+        Consumer consumer = Mockito.mock(Consumer.class);
+        HashSet<TopicPartition> partitions = new HashSet<>();
+        partitions.add(new TopicPartition("test.topic", 0));
+        Mockito.when(consumer.assignment()).thenReturn(partitions);
+
+        // when
+        ConsumerRecords records = initialPollWaitingForConsumerGroupJoin(consumer);
+
+        // then
+        assertThat(records.isEmpty(), is(true));
+    }
+
+    @Test
+    public void test_firstPoll_exits_on_receiving_records() {
+        // given
+        Consumer consumer = Mockito.mock(Consumer.class);
+        Mockito.when(consumer.assignment()).thenReturn(new HashSet<TopicPartition>());
+
+        ConsumerRecords consumerRecords = Mockito.mock(ConsumerRecords.class);
+        Mockito.when(consumer.poll(any(Duration.class))).thenReturn(consumerRecords);
+
+        Mockito.when(consumerRecords.isEmpty()).thenReturn(false);
+
+        // when
+        ConsumerRecords records = initialPollWaitingForConsumerGroupJoin(consumer);
+
+        // then
+        assertThat(records, equalTo(consumerRecords));
+    }
+
+
+    @Test
+    public void test_firstPoll_throws_after_timeout() throws Exception {
+        // given
+        Consumer consumer = Mockito.mock(Consumer.class);
+        Mockito.when(consumer.assignment()).thenReturn(new HashSet<TopicPartition>());
+
+        ConsumerRecords consumerRecords = Mockito.mock(ConsumerRecords.class);
+        Mockito.when(consumer.poll(any(Duration.class))).thenReturn(consumerRecords);
+
+        Mockito.when(consumerRecords.isEmpty()).thenReturn(true);
+
+        // should throw
+        expectedException.expectMessage("Kafka Consumer unable to join in time");
+
+        // when
+        ConsumerRecords records = initialPollWaitingForConsumerGroupJoin(consumer);
     }
 }

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelperTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelperTest.java
@@ -1,10 +1,8 @@
 package org.jsmart.zerocode.core.kafka.helper;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterators;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.hamcrest.CoreMatchers;
 import org.jsmart.zerocode.core.kafka.consume.ConsumerLocalConfigs;
 import org.jsmart.zerocode.core.kafka.consume.ConsumerLocalConfigsWrap;
 import org.jsmart.zerocode.core.kafka.receive.ConsumerCommonConfigs;
@@ -13,7 +11,6 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.io.IOException;

--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelperTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelperTest.java
@@ -28,8 +28,6 @@ public class KafkaConsumerHelperTest {
     ConsumerCommonConfigs consumerCommon;
     ConsumerLocalConfigs consumerLocal;
 
-    //ObjectMapper objectMapper = (new ObjectMapperProvider()).get();
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/kafka-testing/src/test/resources/kafka/consume/test_kafka_consume.json
+++ b/kafka-testing/src/test/resources/kafka/consume/test_kafka_consume.json
@@ -22,6 +22,9 @@
             "url": "kafka-topic:demo-c1",
             "operation": "unload",
             "request": {
+                "consumerLocalConfigs": {
+                    "maxNoOfRetryPollsOrTimeouts": 1
+                }
             },
             "assertions": {
                 // this will be 1  only when consumer does a commit i.e. commitAsync or sync,


### PR DESCRIPTION
# Add initialPoll to wait for consumer group join

[Link to Branch
](https://github.com/ddingel/zerocode/tree/fix-issue-421-KafkaReceiver)

## Motivation and Context
In a kafka consume step, on the first poll, a consumer group join will be triggered. 
This can take multiple seconds to complete. Currently we use will use our maxNoOfRetryPollsOrTimeouts in that time.
If the consumer group join has not finished we return without any result or meaningful message.

The proposed change will move the initial poll out of the loop.
Additionally if the initial poll fails an exception will be thrown.

## Checklist:

* [ X] Unit tests added

* [x] Integration tests added

* [ X] Test names are meaningful

* [ X] Feature manually tested

* [x] Branch build passed

* [ X] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [X ] Not applicable. The changes did not affect HTTP automation flow

* [ X] Kafka test added to `kafka-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect Kafka automation flow
