### PR TITLE
#453 - Use reusable json file inside another json file

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeExternalFileProcessorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeExternalFileProcessorImpl.java
@@ -134,8 +134,14 @@ public class ZeroCodeExternalFileProcessorImpl implements ZeroCodeExternalFilePr
                     if (token != null && token.startsWith(JSON_PAYLOAD_FILE)) {
                         String resourceJsonFile = token.substring(JSON_PAYLOAD_FILE.length());
                         try {
-                            Object jsonFileContent = objectMapper.readTree(readJsonAsString(resourceJsonFile));
-                            entry.setValue(jsonFileContent);
+                            JsonNode jsonNode = objectMapper.readTree(readJsonAsString(resourceJsonFile));
+                            if (jsonNode.isObject()) {
+                                //also replace content of just read json file (recursively)
+                                final Map<String, Object> jsonFileContent = objectMapper.convertValue(jsonNode, Map.class);
+                                digReplaceContent(jsonFileContent);
+                                jsonNode = objectMapper.convertValue(jsonFileContent, JsonNode.class);
+                            }
+                            entry.setValue(jsonNode);
                         } catch (Exception exx) {
                             LOGGER.error("External file reference exception - {}", exx.getMessage());
                             throw new RuntimeException(exx);

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeExternalFileProcessorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeExternalFileProcessorImplTest.java
@@ -40,6 +40,18 @@ public class ZeroCodeExternalFileProcessorImplTest {
     }
 
     @Test
+    public void test_deepRecursiveFile() throws IOException {
+        String jsonAsString = readJsonAsString("unit_test_files/filebody_unit_test/json_step_test_file_recursive.json");
+        Map<String, Object> map = objectMapper.readValue(jsonAsString, new TypeReference<Map<String, Object>>() {});
+
+        externalFileProcessor.digReplaceContent(map);
+        String resultJson = objectMapper.writeValueAsString(map);
+
+        assertThat(read(resultJson, "$.request.body.addresses[0].type"), is("corp-office"));
+        assertThat(read(resultJson, "$.request.body.addresses[1].type"), is("hr-office"));
+    }
+
+    @Test
     public void test_addressArray() throws IOException {
         String jsonAsString = readJsonAsString("unit_test_files/filebody_unit_test/json_step_test_address_array.json");
         Map<String, Object> map = objectMapper.readValue(jsonAsString, new TypeReference<Map<String, Object>>() {});

--- a/core/src/test/resources/unit_test_files/filebody_unit_test/common/common_content_recursive.json
+++ b/core/src/test/resources/unit_test_files/filebody_unit_test/common/common_content_recursive.json
@@ -1,0 +1,6 @@
+{
+    "id": "Emp-No-${RANDOM.NUMBER}",
+    "age": 16,
+    "secret": "passwwrd",
+    "addresses": "${JSON.FILE:unit_test_files/filebody_unit_test/common/comm_addresses.json}"
+}

--- a/core/src/test/resources/unit_test_files/filebody_unit_test/json_step_test_file_recursive.json
+++ b/core/src/test/resources/unit_test_files/filebody_unit_test/json_step_test_file_recursive.json
@@ -1,0 +1,13 @@
+{
+    "name": "create_emp",
+    "url": "/api/test/v1/employess",
+    "operation": "POST",
+    "request": {
+        "headers": "${JSON.FILE:unit_test_files/filebody_unit_test/common/common_content.json}",
+        "body": "${JSON.FILE:unit_test_files/filebody_unit_test/common/common_content_recursive.json}"
+    },
+    "assertions": {
+        "status": 201,
+        "body": "${JSON.FILE:unit_test_files/filebody_unit_test/common/common_content.json}"
+    }
+}

--- a/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldextjsonfile/HelloReuseJsonFileAsContentTest.java
+++ b/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldextjsonfile/HelloReuseJsonFileAsContentTest.java
@@ -16,6 +16,11 @@ public class HelloReuseJsonFileAsContentTest {
     }
 
     @Test
+    @JsonTestCase("helloworld_ext_file_json/hello_world_jsonfile_as_request_body_with_inner_ref.json")
+    public void testHelloWorld_jsonFileAsBody_inception() throws Exception {
+    }
+
+    @Test
     @JsonTestCase("helloworld_ext_file_json/hello_world_jsonfile_as_response_body.json")
     public void testHello_jsonFileAsResponseBody() throws Exception {
     }

--- a/http-testing/src/test/resources/helloworld_ext_file_json/hello_world_jsonfile_as_request_body_with_inner_ref.json
+++ b/http-testing/src/test/resources/helloworld_ext_file_json/hello_world_jsonfile_as_request_body_with_inner_ref.json
@@ -1,0 +1,32 @@
+{
+    "scenarioName": "POST API - File json as request content - Reuse body",
+    "steps": [
+        {
+            "name": "create_emp",
+            "url": "/api/v1/employees",
+            "method": "POST",
+            "request": {
+                "body" : "${JSON.FILE:reusable_content/request/request_body_with_address.json}"
+            },
+            "assertions": {
+                "status": 201
+            }
+        },
+        {
+            "name": "get_user_details",
+            "url": "/api/v1/employees/${$.create_emp.response.body.id}",
+            "method": "GET",
+            "request": {
+            },
+            "assertions": {
+                "status": 200,
+                "body": {
+                    "id": 39001,
+                    "ldapId": "emmanorton",
+                    "name": "Emma",
+                    "surName": "Norton"
+                }
+            }
+        }
+    ]
+}

--- a/http-testing/src/test/resources/reusable_content/request/request_body_with_address.json
+++ b/http-testing/src/test/resources/reusable_content/request/request_body_with_address.json
@@ -1,0 +1,5 @@
+{
+    "name": "Emma",
+    "surName": "Norton",
+    "address": "${JSON.FILE:reusable_content/request/office_address.json}"
+}


### PR DESCRIPTION
#453  Use reusable json file inside another json file

PR Branch
https://github.com/RDBreed/zerocode/tree/453-Use-JSON-file-within-a-reusable-JSON-file

## Motivation and Context
"As Automation Engineer I want to be able to reference a reusable JSON file from another reusable JSON file."

Am committing in the context of **Hacktoberfest**. Hope I can help and feel free when you need any further help!


## Checklist:

* [x] Unit tests added

* [x] Integration tests added

* [x] Test names are meaningful

* [x] Feature manually tested

* [x] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [x] Http test added to `http-testing` module(if applicable) ?
  * [] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
