### PR TITLE
Fix switch case statement

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/client/BasicKafkaClient.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/client/BasicKafkaClient.java
@@ -26,16 +26,23 @@ public class BasicKafkaClient {
         try {
             switch (operation.toLowerCase()) {
                 case "send":
+                    break;
                 case "load":
+                    break;
                 case "publish":
+                    break;
                 case "produce":
                     return sender.send(brokers, topicName, requestJson, scenarioExecutionState);
-
+                    
                 case "unload":
+                    break;
                 case "consume":
-                case "receive":
-                case "subscribe":
                     return receiver.receive(brokers, topicName, requestJson);
+                    
+                case "receive":
+                    break;
+                case "subscribe":
+                    break;
 
                 case "poll":
                     throw new RuntimeException("poll - Not yet Implemented");


### PR DESCRIPTION
Switch case statement need to have `break` after each case, otherwise it will result in a unpredicted behaviour.

# Fix switch case statement

PR Branch
https://github.com/MrXavier/zerocode/tree/patch-2

## Motivation and Context

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [ ] Test names are meaningful

* [ ] Feature manually tested

* [ ] Branch build passed

* [ ] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect Kafka automation flow
