### PR TITLE
ISSUE-472 implement buildUrlPattern function to add url matching regardless query params

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion><build><plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><source>10</source><target>10</target></configuration></plugin>
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+            <source>8</source>
+            <target>8</target>
+        </configuration>
+    </plugin>
+</plugins></build>
     <parent>
         <artifactId>zerocode-tdd-parent</artifactId>
         <groupId>org.jsmart</groupId>

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.StringUtils;
 import org.jsmart.zerocode.core.domain.MockStep;
@@ -18,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
 public class RestEndPointMocker {
@@ -95,28 +97,36 @@ public class RestEndPointMocker {
     }
 
     private static MappingBuilder createDeleteRequestBuilder(MockStep mockStep) {
-        final MappingBuilder requestBuilder = delete(urlEqualTo(mockStep.getUrl()));
+        final MappingBuilder requestBuilder = delete(buildUrlPattern(mockStep.getUrl()));
         return createRequestBuilderWithHeaders(mockStep, requestBuilder);
     }
 
     private static MappingBuilder createPatchRequestBuilder(MockStep mockStep) {
-        final MappingBuilder requestBuilder = patch(urlEqualTo(mockStep.getUrl()));
+        final MappingBuilder requestBuilder = patch(buildUrlPattern(mockStep.getUrl()));
         return createRequestBuilderWithHeaders(mockStep, requestBuilder);
     }
 
     private static MappingBuilder createPutRequestBuilder(MockStep mockStep) {
-        final MappingBuilder requestBuilder = put(urlEqualTo(mockStep.getUrl()));
+        final MappingBuilder requestBuilder = put(buildUrlPattern(mockStep.getUrl()));
         return createRequestBuilderWithHeaders(mockStep, requestBuilder);
     }
 
     private static MappingBuilder createPostRequestBuilder(MockStep mockStep) {
-        final MappingBuilder requestBuilder = post(urlEqualTo(mockStep.getUrl()));
+        final MappingBuilder requestBuilder = post(buildUrlPattern(mockStep.getUrl()));
         return createRequestBuilderWithHeaders(mockStep, requestBuilder);
     }
 
     private static MappingBuilder createGetRequestBuilder(MockStep mockStep) {
-        final MappingBuilder requestBuilder = get(urlEqualTo(mockStep.getUrl()));
+        final MappingBuilder requestBuilder = get(buildUrlPattern(mockStep.getUrl()));
         return createRequestBuilderWithHeaders(mockStep, requestBuilder);
+    }
+
+    private static UrlPattern buildUrlPattern(String url) {
+        if (url.contains("?")) { // match url regardless query parameters
+            return urlPathEqualTo(url);
+        } else { // match url strictly, without path parameters
+            return urlEqualTo(url);
+        }
     }
 
     private static MappingBuilder createRequestBuilderWithHeaders(MockStep mockStep, MappingBuilder requestBuilder) {

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -32,7 +32,7 @@ public class RestEndPointMocker {
     private static boolean hasMoreThanOneStubForUrl(List<String> urls) {
         List<String> urlsCopy = urls.stream().collect(Collectors.toList());
         urlsCopy.stream().map(e -> (e.indexOf("?") >= 0) ? e.substring(0, e.indexOf("?")) : e);
-        return urls.stream().anyMatch(e -> urls.contains(e));
+        return urlsCopy.stream().anyMatch(e -> urlsCopy.contains(e));
     }
 
     public static void createWithWireMock(MockSteps mockSteps, int mockPort) {

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -120,11 +120,18 @@ public class RestEndPointMocker {
     }
 
     private static UrlPattern buildUrlPattern(String url) {
-        if (url.contains("?")) { // if url pattern has query params then match url strictly including query params
+        // if url pattern has query params or Wiremock has already any stub for url, then match url strictly including query params
+        if (url.contains("?") || hasAnyStubForUrl(url)) {
             return urlEqualTo(url);
         } else { // if url pattern doesn't have query params then match url with or without any query parameters
             return urlPathEqualTo(url);
         }
+    }
+
+    private static boolean hasAnyStubForUrl(String url) {
+        return wireMockServer.listAllStubMappings().getMappings().stream().anyMatch(
+                e -> url.contains(e.getRequest().getUrlPath()) || e.getRequest().getUrlPath().contains(url)
+        );
     }
 
     private static MappingBuilder createRequestBuilderWithHeaders(MockStep mockStep, MappingBuilder requestBuilder) {

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -32,7 +32,7 @@ public class RestEndPointMocker {
     private static boolean hasMoreThanOneStubForUrl(List<String> urls) {
         List<String> urlsCopy = urls.stream().collect(Collectors.toList());
         urlsCopy.stream().map(e -> (e.indexOf("?") >= 0) ? e.substring(0, e.indexOf("?")) : e);
-        return urlsCopy.stream().anyMatch(e -> urlsCopy.contains(e)); 
+        return urlsCopy.stream().anyMatch(e -> urlsCopy.contains(e));
     }
 
     public static void createWithWireMock(MockSteps mockSteps, int mockPort) {

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -12,14 +12,12 @@ import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.StringUtils;
 import org.jsmart.zerocode.core.domain.MockStep;
 import org.jsmart.zerocode.core.domain.MockSteps;
-import org.jsmart.zerocode.core.engine.executor.ApiServiceExecutorImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
 public class RestEndPointMocker {
@@ -122,10 +120,10 @@ public class RestEndPointMocker {
     }
 
     private static UrlPattern buildUrlPattern(String url) {
-        if (url.contains("?")) { // match url regardless query parameters
-            return urlPathEqualTo(url);
-        } else { // match url strictly, without path parameters
+        if (url.contains("?")) { // if url pattern has query params then match url strictly including query params
             return urlEqualTo(url);
+        } else { // if url pattern doesn't have query params then match url with or without any query parameters
+            return urlPathEqualTo(url);
         }
     }
 

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -32,7 +32,7 @@ public class RestEndPointMocker {
     private static boolean hasMoreThanOneStubForUrl(List<String> urls) {
         List<String> urlsCopy = urls.stream().collect(Collectors.toList());
         urlsCopy.stream().map(e -> (e.indexOf("?") >= 0) ? e.substring(0, e.indexOf("?")) : e);
-        return urlsCopy.stream().anyMatch(e -> urlsCopy.contains(e));
+        return urlsCopy.stream().anyMatch(e -> urlsCopy.contains(e)); 
     }
 
     public static void createWithWireMock(MockSteps mockSteps, int mockPort) {


### PR DESCRIPTION
# ISSUE-472 implement buildUrlPattern function to add url matching regardless query params

PR Branch
https://github.com/MrXavier/zerocode/tree/ISSUE-472_wiremock_match_url_path_only

## Motivation and Context
Scenario thi PR wants to cover:
Url used in mock step scenario = /google-guys/persons/p001
Request send to Wiremock server = /google-guys/persons/p001?param1=value1&param2=value2
Result = The request is mocked and return the mocked response as expected, regardless the query params.

Again, this suggested change is to allow mock non deterministic requests with random query parameters, like for example, when a request has ID or UUID as query parameter. In this case the values of query params can be any random value. To be able to mock that, Wiremock provides urlPathEqualTo(url) function to solve this exact scenario, which is used in this PR to improve mocking feature in Zerocode.

All described here https://github.com/authorjapps/zerocode/issues/472

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [ ] Test names are meaningful

* [ ] Feature manually tested

* [ ] Branch build passed

* [ ] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect Kafka automation flow
