### PR TITLE
ISSUE-472 implement buildUrlPattern function to add url matching regardless query params

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -12,12 +12,12 @@ import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.StringUtils;
 import org.jsmart.zerocode.core.domain.MockStep;
 import org.jsmart.zerocode.core.domain.MockSteps;
-import org.jsmart.zerocode.core.engine.executor.ApiServiceExecutorImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -30,10 +30,9 @@ public class RestEndPointMocker {
 
     public static Boolean buildUrlPathEqualToPattern_FeatureFlag = true;
 
-    private static boolean hasMoreThanOneStubForUrl(List<String> urls) {
-        List<String> urlsCopy = urls.stream().collect(Collectors.toList());
-        urlsCopy.stream().map(e -> (e.indexOf("?") >= 0) ? e.substring(0, e.indexOf("?")) : e);
-        return urlsCopy.stream().anyMatch(e -> urlsCopy.contains(e));
+    private static boolean hasMoreThanOneStubForSameUrl(List<String> urls) {
+        Set<String> urlsSet = urls.stream().collect(Collectors.toSet());
+        return urlsSet.size() != urls.size();
     }
 
     public static void createWithWireMock(MockSteps mockSteps, int mockPort) {
@@ -41,7 +40,7 @@ public class RestEndPointMocker {
         restartWireMock(mockPort);
 
         List<String> urls = mockSteps.getMocks().stream().map(e -> e.getUrl()).collect(Collectors.toList());
-        if(hasMoreThanOneStubForUrl(urls)) {
+        if (hasMoreThanOneStubForSameUrl(urls)) {
             buildUrlPathEqualToPattern_FeatureFlag = false;
         }
 
@@ -137,7 +136,7 @@ public class RestEndPointMocker {
 
     private static UrlPattern buildUrlPattern(String url) {
         // if url pattern doesn't have query params and feature flag = true, then match url with or without any query parameters
-            if (!url.contains("?") && buildUrlPathEqualToPattern_FeatureFlag) {
+        if (!url.contains("?") && buildUrlPathEqualToPattern_FeatureFlag) {
             return urlPathEqualTo(url);
         } else { // if url pattern has query params then match url strictly including query params
             return urlEqualTo(url);

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -31,6 +31,7 @@ public class RestEndPointMocker {
     public static Boolean buildUrlPathEqualToPattern_FeatureFlag = true;
 
     private static boolean hasMoreThanOneStubForSameUrl(List<String> urls) {
+        if(urls == null) return false;
         Set<String> urlsSet = urls.stream().collect(Collectors.toSet());
         return urlsSet.size() != urls.size();
     }
@@ -136,7 +137,7 @@ public class RestEndPointMocker {
 
     private static UrlPattern buildUrlPattern(String url) {
         // if url pattern doesn't have query params and feature flag = true, then match url with or without any query parameters
-        if (!url.contains("?") && buildUrlPathEqualToPattern_FeatureFlag) {
+        if (url != null && !url.contains("?") && buildUrlPathEqualToPattern_FeatureFlag) {
             return urlPathEqualTo(url);
         } else { // if url pattern has query params then match url strictly including query params
             return urlEqualTo(url);

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMockerTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMockerTest.java
@@ -139,6 +139,34 @@ public class RestEndPointMockerTest {
     }
 
     @Test
+    public void willMockRequest_withAnyQueryParameters() throws Exception {
+
+        int WIRE_MOCK_TEST_PORT = 9077;
+
+        final MockStep mockGetRequest = mockSteps.getMocks().get(0);
+        String respBody = mockGetRequest.getResponse().get("body").toString();
+
+        createWithWireMock(mockSteps, WIRE_MOCK_TEST_PORT);
+
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        HttpGet request = new HttpGet("http://localhost:" + WIRE_MOCK_TEST_PORT + mockGetRequest.getUrl() + "?param1=value1&param2=value2");
+        request.addHeader("key", "key-007");
+        request.addHeader("secret", "secret-007");
+        HttpResponse response = httpClient.execute(request);
+
+        final String responseBodyActual = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+        System.out.println("### response: \n" + responseBodyActual);
+
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+        JSONAssert.assertEquals(respBody, responseBodyActual, true);
+
+        Assert.assertEquals("Content-Type", response.getEntity().getContentType().getName());
+        Assert.assertEquals("application/json", response.getEntity().getContentType().getValue());
+
+        getWireMockServer().stop();
+    }
+
+    @Test
     public void willMockAPostRequest() throws Exception {
 
         final MockStep mockPost = mockSteps.getMocks().get(1);


### PR DESCRIPTION
# ISSUE-472 implement buildUrlPattern function to add url matching regardless query params

PR Branch
https://github.com/MrXavier/zerocode/tree/ISSUE-472_wiremock_match_url_path_only

## Motivation and Context
Scenario thi PR wants to cover:
Url used in mock step scenario = /google-guys/persons/p001
Request send to Wiremock server = /google-guys/persons/p001?param1=value1&param2=value2
Result = The request is mocked and return the mocked response as expected, regardless the query params.

Again, this suggested change is to allow mock non deterministic requests with random query parameters, like for example, when a request has ID or UUID as query parameter. In this case the values of query params can be any random value. To be able to mock that, Wiremock provides urlPathEqualTo(url) function to solve this exact scenario, which is used in this PR to improve mocking feature in Zerocode.

All described here https://github.com/authorjapps/zerocode/issues/472

## Checklist:

* [x] Unit tests added

* [ ] Integration tests added

* [x] Test names are meaningful

* [ ] Feature manually tested

* [x] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect Kafka automation flow
