### PR TITLE
ISSUE-623 : Execute specified previous steps while retrying a given step( for scenarios where current step is dependent on previous steps, such as auth)

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/domain/Retry.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/domain/Retry.java
@@ -1,8 +1,11 @@
 package org.jsmart.zerocode.core.domain;
 
+import java.util.List;
+
 public class Retry {
     private Integer max;
     private Integer delay;
+    private List<String> withSteps;
 
     public Integer getMax() {
         return max;
@@ -12,10 +15,16 @@ public class Retry {
         return delay;
     }
 
+    public List<String> getWithSteps() {
+        return withSteps;
+    }
     public Retry() {}
 
-    public Retry(Integer max, Integer delay) {
+    public Retry(Integer max, Integer delay, List<String> withSteps) {
         this.max = max;
         this.delay = delay;
+        this.withSteps = withSteps;
     }
+
+
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/domain/Step.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/domain/Step.java
@@ -5,10 +5,11 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-/**
+/*
  * Do not enable this @JsonIgnoreProperties(ignoreUnknown = true) as this will suppress the test data failure,
  * let it spit out the exception(s) in case of a bad json/test input
  */

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ScenarioExecutionState.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ScenarioExecutionState.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ScenarioExecutionState {
@@ -29,6 +30,10 @@ public class ScenarioExecutionState {
 
     public void setScenarioStateTemplate(String scenarioStateTemplate) {
         this.scenarioStateTemplate = scenarioStateTemplate;
+    }
+
+    public Optional<StepExecutionState> getExecutedStepState(String stepName) {
+        return Optional.of(allStepsLinkedMap.get(stepName));
     }
 
     public List<StepExecutionState> getAllSteps() {

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ScenarioExecutionState.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ScenarioExecutionState.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.text.StrSubstitutor;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -13,8 +14,8 @@ public class ScenarioExecutionState {
             "  ${STEP_REQUEST_RESPONSE_SECTION}\n" +
             "}";
 
-    List<StepExecutionState> allSteps = new ArrayList<>();
-    List<String> allStepsInStringList = new ArrayList<>();
+
+    Map<String, StepExecutionState> allStepsLinkedMap = new LinkedHashMap<>();
 
     Map<String, String> paramMap = new HashMap<>();
 
@@ -31,29 +32,23 @@ public class ScenarioExecutionState {
     }
 
     public List<StepExecutionState> getAllSteps() {
-        return allSteps;
-    }
-
-    public void setAllSteps(List<StepExecutionState> allSteps) {
-        this.allSteps = allSteps;
+        return new ArrayList<>(allStepsLinkedMap.values());
     }
 
     public List<String> getAllStepsInStringList() {
-        return allStepsInStringList;
+        return allStepsLinkedMap.values()
+                .stream().map(StepExecutionState::getResolvedStep)
+                .collect(Collectors.toList());
     }
 
-    public void setAllStepsInStringList(List<String> allStepsInStringList) {
-        this.allStepsInStringList = allStepsInStringList;
-    }
-
-    public void addStepState(String stepState){
-        allStepsInStringList.add(stepState);
+    public void addStepState(StepExecutionState stepState){
+        //removing key so that order of step state is changed
+        allStepsLinkedMap.remove(stepState.getStepName());
+        allStepsLinkedMap.put(stepState.getStepName(), stepState);
     }
 
     public String getResolvedScenarioState() {
-        final String commaSeparatedStepResults = getAllStepsInStringList().stream()
-                .map(i -> i)
-                .collect(Collectors.joining(", "));
+        final String commaSeparatedStepResults = String.join(", ", getAllStepsInStringList());
         paramMap.put("STEP_REQUEST_RESPONSE_SECTION", commaSeparatedStepResults);
 
         return (new StrSubstitutor(paramMap)).replace(scenarioStateTemplate);

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/StepExecutionState.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/StepExecutionState.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 public class StepExecutionState {
     Map<String, String> paramMap = new HashMap<>();
+    private String stepName;
 
     private static String requestResponseState = "\"${STEP.NAME}\": {\n" +
             "    \"request\":${STEP.REQUEST},\n" +
@@ -27,6 +28,7 @@ public class StepExecutionState {
 
     public void addStep(String stepName) {
         paramMap.put("STEP.NAME", stepName);
+        this.stepName = stepName;
     }
 
     public void addRequest(String requestJson) {
@@ -41,5 +43,9 @@ public class StepExecutionState {
     public String getResolvedStep() {
         StrSubstitutor sub = new StrSubstitutor(paramMap);
         return sub.replace(requestResponseState);
+    }
+
+    public String getStepName() {
+        return stepName;
     }
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/StepExecutionState.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/StepExecutionState.java
@@ -1,15 +1,17 @@
 package org.jsmart.zerocode.core.engine.preprocessor;
 
 import org.apache.commons.lang.text.StrSubstitutor;
+import org.jsmart.zerocode.core.domain.Step;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class StepExecutionState {
     Map<String, String> paramMap = new HashMap<>();
+    private Step step;
     private String stepName;
 
-    private static String requestResponseState = "\"${STEP.NAME}\": {\n" +
+    private String requestResponseState = "\"${STEP.NAME}\": {\n" +
             "    \"request\":${STEP.REQUEST},\n" +
             "    \"response\": ${STEP.RESPONSE}\n" +
             "  }";
@@ -18,17 +20,10 @@ public class StepExecutionState {
         //SmartUtils.readJsonAsString("engine/request_respone_template_scene.json");
     }
 
-    public static String getRequestResponseState() {
-        return requestResponseState;
-    }
-
-    public void setRequestResponseState(String requestResponseState) {
-        this.requestResponseState = requestResponseState;
-    }
-
-    public void addStep(String stepName) {
+    public void addStep(Step step) {
+        this.step = step;
+        this.stepName = step.getName();
         paramMap.put("STEP.NAME", stepName);
-        this.stepName = stepName;
     }
 
     public void addRequest(String requestJson) {
@@ -47,5 +42,9 @@ public class StepExecutionState {
 
     public String getStepName() {
         return stepName;
+    }
+
+    public Step getStep() {
+        return step;
     }
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
@@ -233,6 +233,10 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
         String thisStepName = thisStep.getName();
 
         for (int retryCounter = 0; retryCounter < retryMaxTimes; retryCounter++) {
+            if(retryCounter > 0){
+                LOGGER.warn("\n\n------------>Retrying...[step][attempt-{}][executions-{}]:'{}' -> '{}'",
+                        retryCounter, (retryCounter+1), scenario.getScenarioName(), thisStep.getName());
+            }
             try {
                 if (retryCounter > 0 && !isEmpty(thisStep.getRetry().getWithSteps())) {
                     for (String stepName : thisStep.getRetry().getWithSteps()) {

--- a/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
@@ -6,19 +6,17 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.univocity.parsers.csv.CsvParser;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.BiConsumer;
-
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.jsmart.zerocode.core.constants.ZerocodeConstants.KAFKA_TOPIC;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
 import org.jsmart.zerocode.core.domain.Step;
 import org.jsmart.zerocode.core.domain.builders.ZeroCodeExecReportBuilder;
+import static org.jsmart.zerocode.core.domain.builders.ZeroCodeExecReportBuilder.newInstance;
 import org.jsmart.zerocode.core.domain.builders.ZeroCodeIoWriteBuilder;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
 import org.jsmart.zerocode.core.engine.executor.ApiServiceExecutor;
+import static org.jsmart.zerocode.core.engine.mocker.RestEndPointMocker.wireMockServer;
 import org.jsmart.zerocode.core.engine.preprocessor.ScenarioExecutionState;
 import org.jsmart.zerocode.core.engine.preprocessor.StepExecutionState;
 import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeAssertionsProcessor;
@@ -26,22 +24,23 @@ import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeExternalFileProcesso
 import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeParameterizedProcessor;
 import org.jsmart.zerocode.core.engine.sorter.ZeroCodeSorter;
 import org.jsmart.zerocode.core.engine.validators.ZeroCodeValidator;
+import static org.jsmart.zerocode.core.kafka.helper.KafkaCommonUtils.printBrokerProperties;
 import org.jsmart.zerocode.core.logbuilder.ZerocodeCorrelationshipLogger;
 import org.jsmart.zerocode.core.utils.ApiTypeUtils;
-import org.junit.runner.Description;
-import org.junit.runner.notification.RunNotifier;
-import org.slf4j.Logger;
-
-import static java.util.Optional.ofNullable;
-import static org.jsmart.zerocode.core.constants.ZerocodeConstants.KAFKA_TOPIC;
-import static org.jsmart.zerocode.core.domain.builders.ZeroCodeExecReportBuilder.newInstance;
-import static org.jsmart.zerocode.core.engine.mocker.RestEndPointMocker.wireMockServer;
-import static org.jsmart.zerocode.core.kafka.helper.KafkaCommonUtils.printBrokerProperties;
 import static org.jsmart.zerocode.core.utils.ApiTypeUtils.apiType;
 import static org.jsmart.zerocode.core.utils.RunnerUtils.getFullyQualifiedUrl;
 import static org.jsmart.zerocode.core.utils.RunnerUtils.getParameterSize;
 import static org.jsmart.zerocode.core.utils.SmartUtils.prettyPrintJson;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.slf4j.Logger;
 import static org.slf4j.LoggerFactory.getLogger;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
 
 @Singleton
 public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsScenarioRunner {
@@ -182,7 +181,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
                                           ScenarioSpec scenario, Step thisStep) {
         thisStep = extFileProcessor.resolveExtJsonFile(thisStep);
         thisStep = zeroCodeAssertionsProcessor.resolveJsonContent(thisStep, scenarioExecutionState);
-        
+
         List<Step> thisSteps = extFileProcessor.createFromStepFile(thisStep, thisStep.getId());
         if(null == thisSteps || thisSteps.isEmpty()) thisSteps.add(thisStep);
         Boolean wasExecSuccess = null;
@@ -213,7 +212,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
         // --------------------------------------
         final String requestJsonAsString = thisStep.getRequest().toString();
         StepExecutionState stepExecutionState = new StepExecutionState();
-        stepExecutionState.addStep(thisStep.getName());
+        stepExecutionState.addStep(thisStep);
         String resolvedRequestJson = zeroCodeAssertionsProcessor.resolveStringJson(
                 requestJsonAsString,
                 scenarioExecutionState.getResolvedScenarioState());
@@ -235,7 +234,15 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
 
         for (int retryCounter = 0; retryCounter < retryMaxTimes; retryCounter++) {
             try {
-
+                if (retryCounter > 0 && !isEmpty(thisStep.getRetry().getWithSteps())) {
+                    for (String stepName : thisStep.getRetry().getWithSteps()) {
+                        Optional<StepExecutionState> retryWithStepExecState = scenarioExecutionState.getExecutedStepState(stepName);
+                        if (!retryWithStepExecState.isPresent()) {
+                            throw new RuntimeException("Invalid step to retry with : " + stepName + " has not been executed yet");
+                        }
+                        executeRetry(notifier, description, scenarioExecutionState, scenario, retryWithStepExecState.get().getStep());
+                    }
+                }
                 executionResult = executeApi(logPrefixRelationshipId, thisStep, resolvedRequestJson, scenarioExecutionState);
 
                 // logging response
@@ -246,7 +253,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
                         .response(executionResult);
                 correlLogger.aResponseBuilder().customLog(thisStep.getCustomLog());
                 stepExecutionState.addResponse(executionResult);
-                scenarioExecutionState.addStepState(stepExecutionState.getResolvedStep());
+                scenarioExecutionState.addStepState(stepExecutionState);
 
                 // ---------------------------------
                 // Handle sort section
@@ -255,7 +262,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
                     executionResult = sorter.sortArrayAndReplaceInResponse(thisStep, executionResult, scenarioExecutionState.getResolvedScenarioState());
                     correlLogger.customLog("Updated response: " + executionResult);
                     stepExecutionState.addResponse(executionResult);
-                    scenarioExecutionState.addStepState(stepExecutionState.getResolvedStep());
+                    scenarioExecutionState.addStepState(stepExecutionState);
                 }
 
                 // ---------------------------------

--- a/core/src/test/java/org/jsmart/zerocode/TestUtility.java
+++ b/core/src/test/java/org/jsmart/zerocode/TestUtility.java
@@ -1,0 +1,16 @@
+package org.jsmart.zerocode;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import org.jsmart.zerocode.core.domain.Step;
+
+import java.util.Collections;
+
+public class TestUtility {
+    private TestUtility() {
+
+    }
+
+    public static Step createDummyStep(String stepName) {
+        return new Step(1, null, stepName, "dummy", "dummy", "dummy", null, Collections.emptyList(), NullNode.getInstance(), NullNode.getInstance(), NullNode.getInstance(), "dummy", false);
+    }
+}

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ScenarioExecutionStateTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ScenarioExecutionStateTest.java
@@ -1,19 +1,16 @@
 package org.jsmart.zerocode.core.engine.preprocessor;
 
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.jsmart.zerocode.TestUtility;
 import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class ScenarioExecutionStateTest {
 
     ScenarioExecutionState scenarioExecutionState;
 
     @Before
-    public void initializeSTuff() throws Exception {
+    public void initializeStuff() throws Exception {
         scenarioExecutionState = new ScenarioExecutionState();
     }
 
@@ -22,7 +19,7 @@ public class ScenarioExecutionStateTest {
         JSONAssert.assertEquals(scenarioExecutionState.getResolvedScenarioState(), "{}", true);
 
 
-        final String step1 = createStepWith("Step-1");
+        final StepExecutionState step1 = createStepWith("Step-1");
         scenarioExecutionState.addStepState(step1);
         JSONAssert.assertEquals(scenarioExecutionState.getResolvedScenarioState(), "{\n" +
                 "    \"Step-1\": {\n" +
@@ -37,7 +34,7 @@ public class ScenarioExecutionStateTest {
                 "    }\n" +
                 "}", true);
 
-        final String step2 = createStepWith("Step-2");
+        final StepExecutionState step2 = createStepWith("Step-2");
         scenarioExecutionState.addStepState(step2);
         final String resolvedScene = scenarioExecutionState.getResolvedScenarioState();
         JSONAssert.assertEquals(resolvedScene, "{\n" +
@@ -64,22 +61,18 @@ public class ScenarioExecutionStateTest {
                 "}", true);
     }
 
-    protected String createStepWith(String stepName) {
-        Map<String, String> parammap = new HashMap<>();
-
-        parammap.put("STEP.NAME", stepName);
-        parammap.put("STEP.REQUEST", "{\n" +
+    protected StepExecutionState createStepWith(String stepName) {
+        StepExecutionState stepExecutionState = new StepExecutionState();
+        stepExecutionState.addStep(TestUtility.createDummyStep(stepName));
+        stepExecutionState.addRequest("{\n" +
                 "    \"customer\": {\n" +
                 "        \"firstName\": \"FIRST_NAME\"\n" +
                 "    }\n" +
                 "}");
-        parammap.put("STEP.RESPONSE", "{\n" +
+        stepExecutionState.addResponse("{\n" +
                 "    \"id\" : 10101\n" +
                 "}");
-
-        StrSubstitutor sub = new StrSubstitutor(parammap);
-
-        return sub.replace((new StepExecutionState()).getRequestResponseState());
+        return stepExecutionState;
     }
 
 

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/StepExecutionStateTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/StepExecutionStateTest.java
@@ -1,12 +1,9 @@
 package org.jsmart.zerocode.core.engine.preprocessor;
 
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.jsmart.zerocode.TestUtility;
 import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class StepExecutionStateTest {
     StepExecutionState stepExecutionState;
@@ -19,22 +16,18 @@ public class StepExecutionStateTest {
     @Test
     public void willHaveReqResp_resolved() throws Exception {
 
-        Map<String, String> parammap = new HashMap<>();
-
-        parammap.put("STEP.NAME", "Step-1");
-        parammap.put("STEP.REQUEST", "{\n" +
+        StepExecutionState stepExecutionState = new StepExecutionState();
+        stepExecutionState.addStep(TestUtility.createDummyStep("Step-1"));
+        stepExecutionState.addRequest("{\n" +
                 "    \"customer\": {\n" +
                 "        \"firstName\": \"FIRST_NAME\"\n" +
                 "    }\n" +
                 "}");
-        parammap.put("STEP.RESPONSE", "{\n" +
+        stepExecutionState.addResponse("{\n" +
                 "    \"id\" : 10101\n" +
                 "}");
 
-        StrSubstitutor sub = new StrSubstitutor(parammap);
-        String resolvedString = sub.replace(stepExecutionState.getRequestResponseState());
-
-        JSONAssert.assertEquals(String.format("{%s}", resolvedString), "{\n" +
+        JSONAssert.assertEquals(String.format("{%s}", stepExecutionState.getResolvedStep()), "{\n" +
                 "    \"Step-1\": {\n" +
                 "        \"request\": {\n" +
                 "            \"customer\": {\n" +
@@ -49,8 +42,8 @@ public class StepExecutionStateTest {
     }
 
     @Test
-    public void willBeAbleToAdd_RequestAndReponse() throws Exception {
-        stepExecutionState.addStep("Step-X1");
+    public void willBeAbleToAdd_RequestAndResponse() throws Exception {
+        stepExecutionState.addStep(TestUtility.createDummyStep("Step-X1"));
         stepExecutionState.addRequest("{\n" +
                 "    \"customer\": {\n" +
                 "        \"firstName\": \"FIRST_NAME\"\n" +

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/validators/ZeroCodeValidatorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/validators/ZeroCodeValidatorImplTest.java
@@ -3,12 +3,9 @@ package org.jsmart.zerocode.core.engine.validators;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang.text.StrSubstitutor;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.Is.is;
+import org.jsmart.zerocode.TestUtility;
 import org.jsmart.zerocode.core.di.main.ApplicationMainModule;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
@@ -18,12 +15,11 @@ import org.jsmart.zerocode.core.engine.preprocessor.ScenarioExecutionState;
 import org.jsmart.zerocode.core.engine.preprocessor.StepExecutionState;
 import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeAssertionsProcessorImpl;
 import org.jsmart.zerocode.core.utils.SmartUtils;
+import static org.junit.Assert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import java.util.List;
 
 public class ZeroCodeValidatorImplTest {
     Injector injector;
@@ -93,22 +89,20 @@ public class ZeroCodeValidatorImplTest {
 
     }
 
-    private String createResolvedScenarioState() {
-        Map<String, String> parammap = new HashMap<>();
-
-        parammap.put("STEP.NAME", "produce_step");
-        parammap.put("STEP.REQUEST", "{\n" +
-                        "\"recordType\":\"JSON\"," +
-                        "\"records\":[{\"key\":null,\"headers\":{\"CORRELATION_ID\":\"test\"},\"value\":{\"test\":\"1\"}}]\n" +
+    private StepExecutionState createResolvedScenarioState() {
+        StepExecutionState stepExecutionState = new StepExecutionState();
+        stepExecutionState.addStep(TestUtility.createDummyStep("produce_step"));
+        stepExecutionState.addRequest("{\n" +
+                "\"recordType\":\"JSON\"," +
+                "\"records\":[{\"key\":null,\"headers\":{\"CORRELATION_ID\":\"test\"},\"value\":{\"test\":\"1\"}}]\n" +
                 "}");
-        parammap.put("STEP.RESPONSE", "{\n" +
+        stepExecutionState.addResponse("{\n" +
                 "    \"id\" : 10101\n" +
                 "}");
 
-        StrSubstitutor sub = new StrSubstitutor(parammap);
-
-        return sub.replace((new StepExecutionState()).getRequestResponseState());
+        return stepExecutionState;
     }
+
     @Test
     public void test_validateFlat_nonMatching() throws Exception {
 

--- a/http-testing/pom.xml
+++ b/http-testing/pom.xml
@@ -68,6 +68,8 @@
                         <include>org.jsmart.zerocode.testhelp.tests.helloworldarrayelementmatching.HelloWorldArrayElementPickerTest</include>
                         <include>org.jsmart.zerocode.testhelp.tests.helloworldimplicitdelay.JustHelloImplicitDelayTimeOutTest</include>
                         <include>org.jsmart.zerocode.testhelp.tests.helloworldfileupload.HelloWorldFileUploadTest</include>
+                        <include>org.jsmart.zerocode.testhelp.tests.helloworldretrywithsteps.HelloWorldRetryWithStepsTest</include>
+
                     </includes>
                 </configuration>
             </plugin>

--- a/http-testing/src/main/java/org/jsmart/zerocode/zerocodejavaexec/RetryTestUtility.java
+++ b/http-testing/src/main/java/org/jsmart/zerocode/zerocodejavaexec/RetryTestUtility.java
@@ -10,18 +10,21 @@ public class RetryTestUtility {
     private static int helper2Count = 0;
     private static int helper3Count = 0;
 
-    public static void helperMethod1() {
+    public static Integer helperMethod1() {
         helper1Count++;
+        return helper1Count;
     }
 
-    public static void helperMethod2() {
+    public static Integer helperMethod2() {
         if (helper1Count > helper2Count)
             helper2Count++;
+        return helper2Count;
     }
 
-    public static void helperMethod3() {
+    public static Integer helperMethod3() {
         if (helper2Count > helper3Count)
             helper3Count++;
+        return helper3Count;
     }
 
     public Map<String, String> mainMethod(int requirement) {

--- a/http-testing/src/main/java/org/jsmart/zerocode/zerocodejavaexec/RetryTestUtility.java
+++ b/http-testing/src/main/java/org/jsmart/zerocode/zerocodejavaexec/RetryTestUtility.java
@@ -1,0 +1,36 @@
+package org.jsmart.zerocode.zerocodejavaexec;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class RetryTestUtility {
+
+    private static int helper1Count = 0;
+    private static int helper2Count = 0;
+    private static int helper3Count = 0;
+
+    public static void helperMethod1() {
+        helper1Count++;
+    }
+
+    public static void helperMethod2() {
+        if (helper1Count > helper2Count)
+            helper2Count++;
+    }
+
+    public static void helperMethod3() {
+        if (helper2Count > helper3Count)
+            helper3Count++;
+    }
+
+    public Map<String, String> mainMethod(int requirement) {
+        boolean result = helper1Count >= requirement && helper2Count >= requirement && helper3Count >= requirement;
+        if (result) {
+            helper1Count = 0;
+            helper2Count = 0;
+            helper3Count = 0;
+        }
+        return ImmutableMap.of("success", String.valueOf(result));
+    }
+}

--- a/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldretrywithsteps/HelloWorldRetryWithStepsTest.java
+++ b/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldretrywithsteps/HelloWorldRetryWithStepsTest.java
@@ -1,0 +1,16 @@
+package org.jsmart.zerocode.testhelp.tests.helloworldretrywithsteps;
+
+import org.jsmart.zerocode.core.domain.Scenario;
+import org.jsmart.zerocode.core.runner.ZeroCodeUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ZeroCodeUnitRunner.class)
+public class HelloWorldRetryWithStepsTest {
+
+    @Test
+    @Scenario("helloworld_retry_withSteps/helloworld_retryWithSteps_test.json")
+    public void retry_with_steps_test(){
+
+    }
+}

--- a/http-testing/src/test/resources/helloworld_retry_withSteps/helloworld_retryWithSteps_test.json
+++ b/http-testing/src/test/resources/helloworld_retry_withSteps/helloworld_retryWithSteps_test.json
@@ -1,0 +1,37 @@
+{
+  "scenarioName": "Retry with previous steps",
+  "steps": [
+    {
+      "name" : "helper1",
+      "url": "org.jsmart.zerocode.zerocodejavaexec.RetryTestUtility",
+      "operation": "helperMethod1",
+      "assertions": {}
+    },
+    {
+      "name" : "helper2",
+      "url": "org.jsmart.zerocode.zerocodejavaexec.RetryTestUtility",
+      "operation": "helperMethod2",
+      "assertions": {}
+    },
+    {
+      "name" : "helper3",
+      "url": "org.jsmart.zerocode.zerocodejavaexec.RetryTestUtility",
+      "operation": "helperMethod3",
+      "assertions": {}
+    },
+    {
+      "name" : "main",
+      "url": "org.jsmart.zerocode.zerocodejavaexec.RetryTestUtility",
+      "operation": "mainMethod",
+      "request": "3",
+      "retry": {
+        "max": 3,
+        "delay": 10,
+        "withSteps": ["helper1","helper2", "helper3"]
+      },
+      "assertions": {
+        "success": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# <Feature Title>

PR Branch
**_#ADD LINK TO THE PR BRANCH_**

fixes #623 

## Motivation and Context

The idea here is that instead of maintaining a List<String> for ScenarioExecutionState, we will maintain a LInkedHashMap of StepExecutionState. This will make it easier to mutate ScenarioExecutionState in complex retry scenarios where previously successfully executed steps need to be re-executed (such as in the `withSteps` feature. 


We can now run retries with previously executed steps like so:

```
   {
      "name" : "main",
      "url": "org.jsmart.zerocode.zerocodejavaexec.RetryTestUtility",
      "operation": "mainMethod",
      "request": "3",
      "retry": {
        "max": 3,
        "delay": 10,
        "withSteps": ["helper1","helper2", "helper3"]
      },
      "assertions": {
        "success": "true"
      }
    }
```

This will run the steps mentioned in `withSteps` in the order specified before retrying the step on failure.


## Checklist:

* [x] Unit tests added

* [x] Integration tests added

* [x] Test names are meaningful

* [ ] Feature manually tested

* [x] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [x] Http test added to `http-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
