### PR TITLE
ISSUE-622, ISSUE-626 Java static method and multiple arguments exec support

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/engine/executor/javaapi/JavaMethodExecutorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/executor/javaapi/JavaMethodExecutorImpl.java
@@ -1,18 +1,22 @@
 
 package org.jsmart.zerocode.core.engine.executor.javaapi;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import java.lang.reflect.Method;
-import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static java.lang.Class.forName;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.jsmart.zerocode.core.utils.SmartUtils.prettyPrintJson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JavaMethodExecutorImpl implements JavaMethodExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaMethodExecutorImpl.class);
@@ -38,14 +42,17 @@ public class JavaMethodExecutorImpl implements JavaMethodExecutor {
 
             Object result;
 
-            if (parameterTypes == null || parameterTypes.size() == 0) {
+            if (parameterTypes == null || parameterTypes.isEmpty()) {
 
                 result = executeWithParams(qualifiedClassName, methodName);
 
-            } else {
+            } else if (parameterTypes.size() == 1) {
 
                 Object request = objectMapper.readValue(requestJson, parameterTypes.get(0));
                 result = executeWithParams(qualifiedClassName, methodName, request);
+            } else {
+                Object[] requestArgs = getRequestArgs(parameterTypes, requestJson);
+                result = executeWithParams(qualifiedClassName, methodName, requestArgs);
             }
 
             final String resultJson = objectMapper.writeValueAsString(result);
@@ -58,6 +65,24 @@ public class JavaMethodExecutorImpl implements JavaMethodExecutor {
         }
     }
 
+    private Object[] getRequestArgs(List<Class<?>> parameterTypes, String requestJson) {
+        List<Object> args = new ArrayList<>();
+        JsonNode root = null;
+        try {
+            root = objectMapper.readTree(requestJson);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Could not parse Java method request Json ", e);
+        }
+        for (int i = 0; i < parameterTypes.size(); i++) {
+            try {
+                args.add(objectMapper.treeToValue(root.get(String.valueOf(i)), parameterTypes.get(i)));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Could not convert value " + i + " to type " + parameterTypes.get(i), e);
+            }
+        }
+        return args.toArray();
+    }
+
     /*
      *
      * @param qualifiedClassName : including package name: e.g. "org.jsmart.zerocode.core.AddService"
@@ -67,16 +92,22 @@ public class JavaMethodExecutorImpl implements JavaMethodExecutor {
      */
     Object executeWithParams(String qualifiedClassName, String methodName, Object... params) {
 
-        /**
+        /*
          * Refer SOF example:
          * Q. How do I invoke a Java method when given the method name as a string?
          * Link: https://stackoverflow.com/questions/160970/how-do-i-invoke-a-java-method-when-given-the-method-name-as-a-string
          */
         try {
             Method method = findMatchingMethod(qualifiedClassName, methodName);
-            Object objectToInvokeOn = injector.getInstance(forName(qualifiedClassName));
 
-            return method.invoke(objectToInvokeOn, params);
+            if (Modifier.isStatic(method.getModifiers())) {
+                return method.invoke(null, params);
+            } else {
+                Object objectToInvokeOn = injector.getInstance(forName(qualifiedClassName));
+                return method.invoke(objectToInvokeOn, params);
+            }
+
+
         } catch (Exception e) {
             String errMsg = format("Java exec(): Invocation failed for method %s in class %s", methodName, qualifiedClassName);
             LOGGER.error(errMsg + ". Exception - " + e);

--- a/http-testing/src/main/java/org/jsmart/zerocode/zerocodejavaexec/SampleMethods.java
+++ b/http-testing/src/main/java/org/jsmart/zerocode/zerocodejavaexec/SampleMethods.java
@@ -1,0 +1,41 @@
+package org.jsmart.zerocode.zerocodejavaexec;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class SampleMethods {
+
+    public static class SamplePOJO {
+        public String arg1;
+        public String arg2;
+
+        @JsonCreator
+        public SamplePOJO(@JsonProperty("arg1") String arg1, @JsonProperty("arg2") String arg2) {
+            this.arg1 = arg1;
+            this.arg2 = arg2;
+        }
+    }
+
+    public static Map<String, String> sampleStaticMethod(String arg1, String arg2) {
+        return ImmutableMap.of("0", arg1,
+                "1", arg2);
+    }
+
+    public Map<String, String> sampleMultiArgMethod1(String arg1, String arg2) {
+        return ImmutableMap.of("0", arg1,
+                "1", arg2);
+    }
+
+    public Map<String, Object> sampleMultiArgMethod2(String arg1, Map<String, String> arg2) {
+        return ImmutableMap.of("0", arg1,
+                "1", arg2);
+    }
+
+    public Map<String, Object> sampleMultiArgMethod3(String arg1, SamplePOJO arg2) {
+        return ImmutableMap.of("0", arg1,
+                "1", arg2);
+    }
+}

--- a/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldjavaexec/MultipleArgumentMethodExecTest.java
+++ b/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldjavaexec/MultipleArgumentMethodExecTest.java
@@ -1,0 +1,16 @@
+package org.jsmart.zerocode.testhelp.tests.helloworldjavaexec;
+
+import org.jsmart.zerocode.core.domain.Scenario;
+import org.jsmart.zerocode.core.runner.ZeroCodeUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ZeroCodeUnitRunner.class)
+public class MultipleArgumentMethodExecTest {
+
+    @Test
+    @Scenario("helloworldjavaexec/java_method_multiple_arguments_test.json")
+    public void test_multi_arg_method_exec() throws Exception {
+
+    }
+}

--- a/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldjavaexec/StaticMethodExecTest.java
+++ b/http-testing/src/test/java/org/jsmart/zerocode/testhelp/tests/helloworldjavaexec/StaticMethodExecTest.java
@@ -1,0 +1,16 @@
+package org.jsmart.zerocode.testhelp.tests.helloworldjavaexec;
+
+import org.jsmart.zerocode.core.domain.Scenario;
+import org.jsmart.zerocode.core.runner.ZeroCodeUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ZeroCodeUnitRunner.class)
+public class StaticMethodExecTest {
+
+    @Test
+    @Scenario("helloworldjavaexec/java_static_method_test.json")
+    public void test_multi_arg_method_exec() throws Exception {
+
+    }
+}

--- a/http-testing/src/test/resources/helloworldjavaexec/java_method_multiple_arguments_test.json
+++ b/http-testing/src/test/resources/helloworldjavaexec/java_method_multiple_arguments_test.json
@@ -1,0 +1,56 @@
+{
+  "scenarioName": "Call methods with multiple arguments",
+  "steps": [
+    {
+      "name": "sample method 1",
+      "url": "org.jsmart.zerocode.zerocodejavaexec.SampleMethods",
+      "method": "sampleMultiArgMethod1",
+      "request": {
+        "0" : "arg1",
+        "1" : "arg2"
+      },
+      "assertions": {
+        "0" : "arg1",
+        "1" : "arg2"
+      }
+    },
+    {
+      "name": "sample method 2",
+      "url": "org.jsmart.zerocode.zerocodejavaexec.SampleMethods",
+      "method": "sampleMultiArgMethod2",
+      "request": {
+        "0" : "arg1",
+        "1" : {
+          "key1" : "value1",
+          "key2" : "value2"
+        }
+      },
+      "assertions": {
+        "0" : "arg1",
+        "1" : {
+          "key1" : "value1",
+          "key2" : "value2"
+        }
+      }
+    },
+    {
+      "name": "sample method 3",
+      "url": "org.jsmart.zerocode.zerocodejavaexec.SampleMethods",
+      "method": "sampleMultiArgMethod3",
+      "request": {
+        "0" : "arg1",
+        "1" : {
+          "arg1" : "value1",
+          "arg2" : "value2"
+        }
+      },
+      "assertions": {
+        "0" : "arg1",
+        "1" : {
+          "arg1" : "value1",
+          "arg2" : "value2"
+        }
+      }
+    }
+  ]
+}

--- a/http-testing/src/test/resources/helloworldjavaexec/java_static_method_test.json
+++ b/http-testing/src/test/resources/helloworldjavaexec/java_static_method_test.json
@@ -1,0 +1,24 @@
+{
+  "scenarioName": "Call static method",
+  "steps": [
+    {
+      "name": "sample static method 1",
+      "url": "org.jsmart.zerocode.zerocodejavaexec.SampleMethods",
+      "method": "sampleStaticMethod",
+      "request": {
+        "0" : "arg1",
+        "1" : "arg2"
+      },
+      "assertions": {
+        "0" : "arg1",
+        "1" : "arg2"
+      }
+    },
+    {
+      "name": "calling existing method",
+      "url": "java.lang.System",
+      "method": "currentTimeMillis",
+      "assertions": "$NOT.NULL"
+    }
+  ]
+}


### PR DESCRIPTION
1. Support for multiple parameters in java method exec
2. Support for static method Exec
3. Minor refactoring changes

fixes #622 , #626 

# <Feature Title>

[PR Branch](https://github.com/a1shadows/zerocode/tree/issue-622/static-method-support)

## Motivation and Context
With this PR, it will be possible to do java exec of static methods as well as methods with multiple arguments.

For static methods, they have to be invoked in exactly the same way as instance methods were invoked up to this point.

As for methods with multiple arguments, let's say there is a method like so
```
public Map<String, String> sampleMultiArgMethod1(String arg1, String arg2)
```
It would be invoked in the following way:
```
{
      "name": "sample method 1",
      "url": "org.jsmart.zerocode.zerocodejavaexec.SampleMethods",
      "method": "sampleMultiArgMethod1",
      "request": {
        "0" : "arg1value",
        "1" : "arg2value"
      }
```
The arguments will have to be provided as a json with the key being the 0 indexed order of occurrence in the java method argument list.



## Checklist:

* [x] Unit tests added

* [x] Integration tests added

* [x] Test names are meaningful

* [x] Feature manually tested

* [x] Branch build passed

* [ ] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [x] Http test added to `http-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
