### PR TITLE
Fix for seekTo feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Downloading docker-compose files
         run: wget https://raw.githubusercontent.com/authorjapps/zerocode-docker-factory/master/compose/kafka-schema-registry.yml
       - name: Running Kafka
-        run: docker-compose -f kafka-schema-registry.yml up -d && sleep 10
+        run: docker-compose -f docker/compose/kafka-schema-registry.yml up -d && sleep 10
       - name: Building and testing the changes
         run: mvn clean test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,6 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
-      - name: Downloading docker-compose files
-        run: wget https://raw.githubusercontent.com/authorjapps/zerocode-docker-factory/master/compose/kafka-schema-registry.yml
       - name: Running Kafka
         run: docker-compose -f docker/compose/kafka-schema-registry.yml up -d && sleep 10
       - name: Building and testing the changes

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelper.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelper.java
@@ -450,7 +450,9 @@ public class KafkaConsumerHelper {
             Map<TopicPartition, Long> topicPartitionTimestampMap = topicPartitions.stream()
                     .collect(Collectors.toMap(Function.identity(), ignore -> epoch));
             Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetAndTimestampMap = consumer.offsetsForTimes(topicPartitionTimestampMap);
+
             //removing partitions that are null, since we will only subscribe to partitions that have messages after the given timestamp
+            //by default partitions with no valid offset mapped to timestamp will also be returned by the method with value null. We will skip these
             topicPartitionOffsetAndTimestampMap = topicPartitionOffsetAndTimestampMap.entrySet()
                     .stream()
                     .filter(entry -> entry.getValue() != null)

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelper.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaConsumerHelper.java
@@ -450,6 +450,11 @@ public class KafkaConsumerHelper {
             Map<TopicPartition, Long> topicPartitionTimestampMap = topicPartitions.stream()
                     .collect(Collectors.toMap(Function.identity(), ignore -> epoch));
             Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetAndTimestampMap = consumer.offsetsForTimes(topicPartitionTimestampMap);
+            //removing partitions that are null, since we will only subscribe to partitions that have messages after the given timestamp
+            topicPartitionOffsetAndTimestampMap = topicPartitionOffsetAndTimestampMap.entrySet()
+                    .stream()
+                    .filter(entry -> entry.getValue() != null)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             //assign to fetched partitions
             consumer.unsubscribe();

--- a/docker/compose/kafka-schema-registry.yml
+++ b/docker/compose/kafka-schema-registry.yml
@@ -21,6 +21,22 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
+  init-kafka-container:
+    image: confluentinc/cp-kafka:5.5.1
+    depends_on:
+      - kafka
+    entrypoint: [ '/bin/sh', '-c' ]
+    command: |
+      "
+      # rather than giving sleep 15 use this 
+      # to block init container to wait for Kafka broker to be ready  
+      kafka-topics --bootstrap-server kafka:9092 --list
+
+      # create init topics
+      kafka-topics --create --partitions 3 --bootstrap-server kafka:9092 --topic demo-seekTime-multi-partition
+      "
+
+
   schema-registry:
       image: confluentinc/cp-schema-registry:5.5.1
       depends_on:

--- a/kafka-testing/src/test/resources/kafka/consume/test_kafka_consume_seek_epoch_and_timestamp.json
+++ b/kafka-testing/src/test/resources/kafka/consume/test_kafka_consume_seek_epoch_and_timestamp.json
@@ -3,7 +3,7 @@
   "steps": [
     {
       "name": "load_kafka_before_timestamp",
-      "url": "kafka-topic:demo-seekTime",
+      "url": "kafka-topic:demo-seekTime-multi-partition",
       "operation": "PRODUCE",
       "request": {
         "records": [
@@ -33,7 +33,7 @@
     },
     {
       "name": "load_kafka_after_timestamp",
-      "url": "kafka-topic:demo-seekTime",
+      "url": "kafka-topic:demo-seekTime-multi-partition",
       "operation": "PRODUCE",
       "request": {
         "records": [
@@ -53,7 +53,7 @@
     },
     {
       "name": "consume_seekEpoch",
-      "url": "kafka-topic:demo-seekTime",
+      "url": "kafka-topic:demo-seekTime-multi-partition",
       "operation": "CONSUME",
       "request": {
         "consumerLocalConfigs": {
@@ -64,6 +64,11 @@
           "maxNoOfRetryPollsOrTimeouts": 3
         }
       },
+      "sort": {
+        "key": "value",
+        "order": "natural",
+        "path": "$.records"
+      },
       "verify": {
         "records": [
           {
@@ -73,10 +78,11 @@
             "value": "After Timestamp 2"
           }
         ]
-      }},
+      }
+    },
     {
       "name": "consume_seekTimestamp",
-      "url": "kafka-topic:demo-seekTime",
+      "url": "kafka-topic:demo-seekTime-multi-partition",
       "operation": "CONSUME",
       "request": {
         "consumerLocalConfigs": {
@@ -90,6 +96,11 @@
           "maxNoOfRetryPollsOrTimeouts": 3
         }
       },
+      "sort": {
+        "key": "value",
+        "order": "natural",
+        "path": "$.records"
+      },
       "verify": {
         "records": [
           {
@@ -98,7 +109,8 @@
           {
             "value": "After Timestamp 2"
           }
-        ]
+        ],
+        "size": 2
       }
     }
   ]


### PR DESCRIPTION
# <Feature Title>

Fixes #631 

PR Branch
**_#ADD LINK TO THE PR BRANCH_**

## Motivation and Context
If there are partitions for which there is no valid offset corresponding to the timestamp to seek to, the offsetForTimestamp method still includes it in the Map returned, but with a NULL value. We need to skip all partitions that have offset as NULL when subscribing to avoid an error when we try to seek to the offset at a later step.

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [ ] Test names are meaningful

* [ ] Feature manually tested

* [ ] Branch build passed

* [ ] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect Kafka automation flow
