### PR TITLE
upgrade logback from 1.0.7 to 1.3.14 and slf4j to 2.0.12

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -9,12 +9,10 @@
 	</appender>
 
 	<appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-		<!--<encoder>
-			<pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
-		</encoder>-->
-		<layout class="ch.qos.logback.classic.PatternLayout">
+		<encoder>
+			<!--<pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>-->
 			<pattern>%d %green([%thread]) %highlight(%level) %logger{100} - %blue(%msg%n)</pattern>
-		</layout>
+		</encoder>
 	</appender>
 
 	<root level="INFO">

--- a/http-testing/src/main/resources/logback.xml
+++ b/http-testing/src/main/resources/logback.xml
@@ -9,13 +9,11 @@
     </appender>
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <!--<encoder>
-            <pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
-        </encoder>-->
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
+            <!--<pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>-->
             <!--<pattern>%d %green([%thread]) %highlight(%level) %logger{100} - %blue(%msg%n)</pattern>-->
             <pattern>%d [%thread] %-5level %logger{100} - %msg%n</pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <root level="INFO">

--- a/http-testing/src/test/resources/logback.xml
+++ b/http-testing/src/test/resources/logback.xml
@@ -9,13 +9,11 @@
     </appender>
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <!--<encoder>
-            <pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
-        </encoder>-->
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
+            <!--<pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>-->
             <!--<pattern>%d %green([%thread]) %highlight(%level) %logger{100} - %blue(%msg%n)</pattern>-->
             <pattern>%d [%thread] %-5level %logger{100} - %msg%n</pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <root level="WARN"> <!-- Update this value to see or prevent verbose outputs -->

--- a/junit5-testing/pom.xml
+++ b/junit5-testing/pom.xml
@@ -12,11 +12,6 @@
     <name>Zerocode JUnit5 Jupiter Load Testing</name>
     <description>Zerocode tests with JUnit5 Jupiter Engine</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-        <micro-simulator.version>1.1.8</micro-simulator.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <artifactId>zerocode-tdd</artifactId>

--- a/junit5-testing/src/main/resources/logback.xml
+++ b/junit5-testing/src/main/resources/logback.xml
@@ -9,13 +9,11 @@
     </appender>
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <!--<encoder>
-            <pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
-        </encoder>-->
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder class="ch.qos.logback.classic.PatternLayout">
+            <!--<pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>-->
             <!--<pattern>%d %green([%thread]) %highlight(%level) %logger{100} - %blue(%msg%n)</pattern>-->
             <pattern>%d [%thread] %-5level %logger{100} - %msg%n</pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <root level="INFO">

--- a/kafka-testing/src/main/resources/logback.xml
+++ b/kafka-testing/src/main/resources/logback.xml
@@ -9,13 +9,11 @@
     </appender>
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <!--<encoder>
-            <pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
-        </encoder>-->
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
+            <!--<pattern>%d [%thread] %-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>-->
             <!--<pattern>%d %green([%thread]) %highlight(%level) %logger{100} - %blue(%msg%n)</pattern>-->
             <pattern>%d [%thread] %-5level %logger{100} - %msg%n</pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <root level="INFO">

--- a/kafka-testing/src/test/resources/logback.xml
+++ b/kafka-testing/src/test/resources/logback.xml
@@ -10,9 +10,9 @@
     </appender>
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
             <pattern>%d [%thread] %-5level %logger{30} - %msg%n</pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <!-- Update level to DEBUG or INFO to get more detailed operations -->

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,9 @@
         <commons-lang.version>2.6</commons-lang.version>
         <jayway-version>2.2.0</jayway-version>
         <resteasy-jaxrs.version>2.2.1.GA</resteasy-jaxrs.version>
-        <logback.version>1.0.7</logback.version>
+        <!-- logback 1.4.x and 1.5.x need JDK11 -->
+        <logback.version>1.3.14</logback.version>
+        <slf4j.version>2.0.12</slf4j.version>
         <wiremock.version>2.19.0</wiremock.version>
         <velocity.version>1.7</velocity.version>
         <jackson-dataformat-csv.version>2.9.8</jackson-dataformat-csv.version>
@@ -176,6 +178,16 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
# upgrade logback from 1.0.7 to 1.3.14

PR Branch
https://github.com/baulea/zerocode/tree/upgrade_logback

## Motivation and Context

- upgrade multiple maven dependencies for later Java17 compatibility, Issue https://github.com/authorjapps/zerocode/issues/607
- logback 1.0.7 has vulnerabilities, which are removed in 1.3.14: https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
This also solves https://github.com/authorjapps/zerocode/pull/533 and https://github.com/authorjapps/zerocode/pull/499

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [x] Test names are meaningful

* [x] Feature manually tested

* [x] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [x] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
