### PR TITLE
Upgrade to org.apache.velocity:velocity-engine-core:2.3

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -160,6 +160,10 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jsmart</groupId>

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMocker.java
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.matching.UrlPattern;
-import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.collections4.map.HashedMap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.jsmart.zerocode.core.domain.MockStep;

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImpl.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.univocity.parsers.csv.CsvParser;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
 import org.slf4j.Logger;

--- a/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
@@ -7,7 +7,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.univocity.parsers.csv.CsvParser;
 import static java.util.Optional.ofNullable;
-import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.jsmart.zerocode.core.constants.ZerocodeConstants.KAFKA_TOPIC;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
 import org.jsmart.zerocode.core.domain.Step;

--- a/junit5-testing/pom.xml
+++ b/junit5-testing/pom.xml
@@ -58,7 +58,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.velocity</groupId>
-                    <artifactId>velocity</artifactId>
+                    <artifactId>velocity-engine-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
         <resteasy-jaxrs.version>2.2.1.GA</resteasy-jaxrs.version>
         <logback.version>1.0.7</logback.version>
         <wiremock.version>2.19.0</wiremock.version>
-        <velocity.version>1.7</velocity.version>
         <jackson-dataformat-csv.version>2.9.8</jackson-dataformat-csv.version>
         <commons-io.version>2.15.0</commons-io.version>
         <micro-simulator.version>1.1.10</micro-simulator.version>
@@ -149,8 +148,8 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity</artifactId>
-                <version>${velocity.version}</version>
+                <artifactId>velocity-engine-core</artifactId>
+                <version>2.3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -253,6 +252,11 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>${httpmime.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.4</version>
             </dependency>
             <dependency>
                 <groupId>org.jsmart</groupId>


### PR DESCRIPTION
# Upgrade to org.apache.velocity:velocity-engine-core:2.3

## Fixes Issue
- [x] Which issue or ticket was(will be) fixed in this PR? partially fixes https://github.com/authorjapps/zerocode/issues/607

PR Branch
https://github.com/baulea/zerocode/tree/upgrade_velocity-engine-core

## Motivation and Context

- upgrade multiple maven dependencies for later Java17 compatibility, Issue https://github.com/authorjapps/zerocode/issues/607
- resolve vulnerability [CVE-2020-13936](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13936) in org.apache.velocity:velocity:1.7

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [x] Test names are meaningful

* [x] Feature manually tested

* [x] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [x] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
