### PR TITLE
Upgrade to org.apache.kafka:kafka-clients:3.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <httpmime.version>4.5.12</httpmime.version>
         <h2.db.version>1.4.191</h2.db.version>
         <extentreports.version>5.0.9</extentreports.version>
-        <version.kafka-clients>3.3.1</version.kafka-clients>
+        <version.kafka-clients>3.7.0</version.kafka-clients>
         <version.gson>2.10.1</version.gson>
         <version.univocity-parsers>2.8.2</version.univocity-parsers>
 
@@ -102,7 +102,6 @@
         <!-- Release Build will not fail if error occurs during javadoc generation -->
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <google.protobuf.version>3.24.4</google.protobuf.version>
-        <version.snappy-java>1.1.8.4</version.snappy-java>
     </properties>
 
     <dependencyManagement>
@@ -136,11 +135,6 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${version.kafka-clients}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${version.snappy-java}</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>


### PR DESCRIPTION
# Upgrade to org.apache.kafka:kafka-clients:3.7.0

## Fixes Issue
- [x] Which issue or ticket was(will be) fixed in this PR? partially fixes https://github.com/authorjapps/zerocode/issues/607

PR Branch
https://github.com/baulea/zerocode/tree/upgrade_kafka

## Motivation and Context

- upgrade multiple maven dependencies for later Java17 compatibility, Issue https://github.com/authorjapps/zerocode/issues/607
- resolve vulnerabilities [CVE-2023-43642](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-43642) [CVE-2023-34455](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34455) [CVE-2023-34454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34454) [CVE-2023-34453](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34453) from transitive dependency in org.xerial.snappy:snappy-java:1.1.8.4
- resolves https://github.com/authorjapps/zerocode/pull/636

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [x] Test names are meaningful

* [x] Feature manually tested

* [x] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [x] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
