### PR TITLE
Upgrading Jackson, Guice, Guava and jsonassert

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/di/module/CsvParserModule.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/module/CsvParserModule.java
@@ -3,7 +3,7 @@ package org.jsmart.zerocode.core.di.module;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.univocity.parsers.csv.CsvParser;
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import org.jsmart.zerocode.core.di.provider.CsvParserProvider;
 
 public class CsvParserModule implements Module {

--- a/core/src/main/java/org/jsmart/zerocode/core/di/module/GsonModule.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/module/GsonModule.java
@@ -3,9 +3,8 @@ package org.jsmart.zerocode.core.di.module;
 import com.google.gson.Gson;
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import jakarta.inject.Singleton;
 import org.jsmart.zerocode.core.di.provider.GsonSerDeProvider;
-
-import javax.inject.Singleton;
 
 
 public class GsonModule implements Module {

--- a/core/src/main/java/org/jsmart/zerocode/core/di/module/HttpClientModule.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/module/HttpClientModule.java
@@ -2,10 +2,9 @@ package org.jsmart.zerocode.core.di.module;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import jakarta.inject.Singleton;
 import org.jsmart.zerocode.core.di.provider.DefaultGuiceHttpClientProvider;
 import org.jsmart.zerocode.core.httpclient.BasicHttpClient;
-
-import javax.inject.Singleton;
 
 public class HttpClientModule implements Module {
 

--- a/core/src/main/java/org/jsmart/zerocode/core/di/module/ObjectMapperModule.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/module/ObjectMapperModule.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
+import jakarta.inject.Singleton;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
-import javax.inject.Singleton;
 import org.jsmart.zerocode.core.di.provider.YamlObjectMapperProvider;
 
 public class ObjectMapperModule implements Module {

--- a/core/src/main/java/org/jsmart/zerocode/core/di/provider/CsvParserProvider.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/provider/CsvParserProvider.java
@@ -2,7 +2,7 @@ package org.jsmart.zerocode.core.di.provider;
 
 import com.univocity.parsers.csv.CsvParser;
 import com.univocity.parsers.csv.CsvParserSettings;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class CsvParserProvider implements Provider<CsvParser> {
     public static final String LINE_SEPARATOR = "\n";

--- a/core/src/main/java/org/jsmart/zerocode/core/di/provider/DefaultGuiceHttpClientProvider.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/provider/DefaultGuiceHttpClientProvider.java
@@ -1,9 +1,8 @@
 package org.jsmart.zerocode.core.di.provider;
 
+import jakarta.inject.Provider;
 import org.jsmart.zerocode.core.httpclient.BasicHttpClient;
 import org.jsmart.zerocode.core.httpclient.ssl.SslTrustHttpClient;
-
-import javax.inject.Provider;
 
 public class DefaultGuiceHttpClientProvider implements Provider<BasicHttpClient> {
 

--- a/core/src/main/java/org/jsmart/zerocode/core/di/provider/GsonSerDeProvider.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/provider/GsonSerDeProvider.java
@@ -8,10 +8,10 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
+import jakarta.inject.Provider;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
-import javax.inject.Provider;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/core/src/main/java/org/jsmart/zerocode/core/di/provider/ObjectMapperProvider.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/provider/ObjectMapperProvider.java
@@ -2,8 +2,7 @@ package org.jsmart.zerocode.core.di.provider;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class ObjectMapperProvider implements Provider<ObjectMapper> {
 

--- a/core/src/main/java/org/jsmart/zerocode/core/di/provider/YamlObjectMapperProvider.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/provider/YamlObjectMapperProvider.java
@@ -3,7 +3,7 @@ package org.jsmart.zerocode.core.di.provider;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 
 public class YamlObjectMapperProvider implements Provider<ObjectMapper> {
 

--- a/core/src/main/java/org/jsmart/zerocode/core/domain/MockStep.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/domain/MockStep.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 /**
@@ -46,31 +48,31 @@ public class MockStep {
     }
 
     public JsonNode getRequest() {
-        return request;
+        return Optional.ofNullable(request).orElse(NullNode.getInstance());
     }
 
     public JsonNode getResponse() {
-        return response;
+        return Optional.ofNullable(response).orElse(NullNode.getInstance());
     }
 
     public JsonNode getAssertions() {
-        return assertions;
+        return Optional.ofNullable(assertions).orElse(NullNode.getInstance());
     }
 
     public String getBody() {
-        final JsonNode bodyNode = request.get("body");
-        return bodyNode != null ? request.get("body").toString() : null;
+        final JsonNode bodyNode = getRequest().get("body");
+        return bodyNode != null ? getRequest().get("body").toString() : null;
     }
 
     public String getHeaders() {
-        return request.get("headers").toString();
+        return getRequest().get("headers").toString();
     }
 
     public Map<String, Object> getHeadersMap() {
         ObjectMapper objectMapper = new ObjectMapperProvider().get();
         HashMap<String, Object> headersMap = new HashMap<>();
         try {
-            final JsonNode headersNode = request.get("headers");
+            final JsonNode headersNode = getRequest().get("headers");
             if (null != headersNode) {
                 headersMap = (HashMap<String, Object>) objectMapper.readValue(headersNode.toString(), HashMap.class);
             }

--- a/core/src/main/java/org/jsmart/zerocode/core/domain/Parameterized.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/domain/Parameterized.java
@@ -27,7 +27,7 @@ public class Parameterized {
             @JsonProperty("ignoreHeader") Boolean ignoreHeader) {
         this.valueSource = valueSource;
         this.ignoreHeader = Optional.ofNullable(ignoreHeader).orElse(false);
-        this.csvSource = getCsvSourceFrom(csvSourceJsonNode);
+        this.csvSource = Optional.ofNullable(csvSourceJsonNode).map(this::getCsvSourceFrom).orElse(Collections.emptyList());
     }
 
     public List<Object> getValueSource() {

--- a/core/src/main/java/org/jsmart/zerocode/core/domain/Step.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/domain/Step.java
@@ -159,7 +159,7 @@ public class Step {
         this.request = request;
         this.url = url;
         this.sort = sort;
-        this.assertions = assertions.isNull() ? verify : assertions;
+        this.assertions = assertions == null || assertions.isNull() ? verify : assertions;
         this.verify = verify;
         this.ignoreStep = ignoreStep;
     }

--- a/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/runner/ZeroCodeMultiStepsScenarioRunnerImpl.java
@@ -2,6 +2,7 @@ package org.jsmart.zerocode.core.runner;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -39,6 +40,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -210,7 +212,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
         // --------------------------------------
         // Save step execution state in a context
         // --------------------------------------
-        final String requestJsonAsString = thisStep.getRequest().toString();
+        final String requestJsonAsString = Optional.ofNullable(thisStep.getRequest()).orElse(NullNode.getInstance()).toString();
         StepExecutionState stepExecutionState = new StepExecutionState();
         stepExecutionState.addStep(thisStep);
         String resolvedRequestJson = zeroCodeAssertionsProcessor.resolveStringJson(
@@ -262,7 +264,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
                 // ---------------------------------
                 // Handle sort section
                 // ---------------------------------
-                if (!thisStep.getSort().isNull()) {
+                if (!Objects.isNull(thisStep.getSort())) {
                     executionResult = sorter.sortArrayAndReplaceInResponse(thisStep, executionResult, scenarioExecutionState.getResolvedScenarioState());
                     correlLogger.customLog("Updated response: " + executionResult);
                     stepExecutionState.addResponse(executionResult);
@@ -273,7 +275,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
                 // Handle assertion section -START
                 // ---------------------------------
                 String resolvedAssertionJson = zeroCodeAssertionsProcessor.resolveStringJson(
-                        thisStep.getAssertions().toString(),
+                        Optional.ofNullable(thisStep.getAssertions()).orElse(NullNode.getInstance()).toString(),
                         scenarioExecutionState.getResolvedScenarioState()
                 );
 
@@ -557,7 +559,7 @@ public class ZeroCodeMultiStepsScenarioRunnerImpl implements ZeroCodeMultiStepsS
         // --------------------
         //  Validators (pyrest)
         // --------------------
-        if (ofNullable(thisStep.getValidators()).orElse(null) != null) {
+        if (thisStep.getValidators() != null) {
             failureResults = validator.validateFlat(thisStep, actualResult, resolvedScenarioState);
         }
 

--- a/core/src/test/java/org/jsmart/zerocode/core/domain/ScenarioSpecTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/domain/ScenarioSpecTest.java
@@ -2,6 +2,7 @@ package org.jsmart.zerocode.core.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
 import org.jsmart.zerocode.core.di.main.ApplicationMainModule;
 import org.jsmart.zerocode.core.utils.SmartUtils;
 import org.jukito.JukitoRunner;
@@ -11,7 +12,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import javax.inject.Inject;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMockerTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMockerTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import jakarta.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
@@ -31,7 +32,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import javax.inject.Inject;
 
 import java.util.Map;
 

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImplTest.java
@@ -2,7 +2,7 @@ package org.jsmart.zerocode.core.engine.preprocessor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.univocity.parsers.csv.CsvParser;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import org.jsmart.zerocode.core.di.main.ApplicationMainModule;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
 import org.jsmart.zerocode.core.utils.SmartUtils;

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <junit5.version>5.4.2</junit5.version>
         <junit.vintage.version>5.4.2</junit.vintage.version>
         <junit-platform-runner.version>1.4.2</junit-platform-runner.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
         <jackson-databind.version>2.15.4</jackson-databind.version>
         <guava.version>33.0.0-jre</guava.version>
         <jsonassert.version>1.5.1</jsonassert.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,12 @@
         <junit.vintage.version>5.4.2</junit.vintage.version>
         <junit-platform-runner.version>1.4.2</junit-platform-runner.version>
         <junit.version>4.12</junit.version>
-        <jackson-databind.version>2.10.0</jackson-databind.version>
-        <guava.version>23.0</guava.version>
-        <jsonassert.version>1.5.0</jsonassert.version>
+        <jackson-databind.version>2.15.4</jackson-databind.version>
+        <guava.version>33.0.0-jre</guava.version>
+        <jsonassert.version>1.5.1</jsonassert.version>
         <classpath-explorer.version>1.0</classpath-explorer.version>
         <jukito.version>1.5</jukito.version>
-        <guice.version>4.0</guice.version>
+        <guice.version>7.0.0</guice.version>
         <commons-lang.version>2.6</commons-lang.version>
         <jayway-version>2.2.0</jayway-version>
         <resteasy-jaxrs.version>2.2.1.GA</resteasy-jaxrs.version>


### PR DESCRIPTION
# <Feature Title>

## Fixes Issue
- [ ] Which issue or ticket was(will be) fixed in this PR?
partially fixes #607 
resolves #642 

PR Branch
**_#ADD LINK TO THE PR BRANCH_**

## Motivation and Context

Notable changes include 

1. adding null checks to JsonNodes because recent Jackson versions deserialize null values to Java null instead of Jackson NullNode
2. Moving from javax.inject to jakarta.inject with latest Guice version

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [ ] Test names are meaningful

* [ ] Feature manually tested

* [ ] Branch build passed

* [ ] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [ ] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [ ] Not applicable. The changes did not affect Kafka automation flow
