### PR TITLE
Upgrade jackson and resteasy

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -103,6 +103,10 @@
             <artifactId>resteasy-jaxrs</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>

--- a/core/src/main/java/org/jsmart/zerocode/core/utils/HelperJsonUtils.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/utils/HelperJsonUtils.java
@@ -9,8 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
-import org.jboss.resteasy.client.ClientRequest;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
 import org.slf4j.LoggerFactory;
@@ -63,7 +61,7 @@ public class HelperJsonUtils {
     }
 
     public static Map<String, Object> readObjectAsMap(Object jsonContent) {
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map;
         try {
             map = mapper.readValue(jsonContent.toString(), HashMap.class);
         } catch (IOException exx) {
@@ -72,43 +70,6 @@ public class HelperJsonUtils {
         }
 
         return map;
-    }
-
-    public static String createAndReturnAssertionResultJson(int httpResponseCode,
-                                                            String resultBodyContent, String locationHref) {
-        LOGGER.debug("\n#locationHref: " + locationHref);
-
-        if (StringUtils.isEmpty(resultBodyContent)) {
-            resultBodyContent = "{}";
-        }
-        String locationField = locationHref != null ? "	\"Location\" : \"" + locationHref + "\",\n" : "";
-        String assertJson = "{\n" +
-                "	\"status\" : " + httpResponseCode + ",\n" +
-                locationField +
-                "	\"body\" : " + resultBodyContent + "\n" +
-                " }";
-
-        String formattedStr = SmartUtils.prettyPrintJson(assertJson);
-
-        return formattedStr;
-    }
-
-    private void setRequestHeaders(Object headers, ClientRequest clientExecutor) {
-        Map<String, Object> headersMap = HelperJsonUtils.readObjectAsMap(headers);
-        for (Object key : headersMap.keySet()) {
-            clientExecutor.header((String) key, headersMap.get(key));
-        }
-    }
-
-    public static String javaObjectAsString(Object value) {
-
-        try {
-            ObjectMapper ow = new ObjectMapperProvider().get();
-            return ow.writeValueAsString(value);
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Exception while converting IPT Java Object to JsonString" + e);
-        }
     }
 
 

--- a/core/src/main/java/org/jsmart/zerocode/core/zzignored/mocking/WireMockJsonContentTesting.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/zzignored/mocking/WireMockJsonContentTesting.java
@@ -2,12 +2,15 @@ package org.jsmart.zerocode.core.zzignored.mocking;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.jboss.resteasy.client.ClientRequest;
-import org.jboss.resteasy.client.ClientResponse;
-import org.jboss.resteasy.client.core.executors.ApacheHttpClientExecutor;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
@@ -36,12 +39,10 @@ public class WireMockJsonContentTesting {
                         .withHeader("Content-Type", APPLICATION_JSON)
                         .withBody(jsonBodyRequest)));
 
-        ApacheHttpClientExecutor httpClientExecutor = new ApacheHttpClientExecutor();
-        ClientRequest clientExecutor = httpClientExecutor.createRequest("http://localhost:9073/identitymanagement-services/identitymanagement-services/person/internalHandle/person_id_009/biographics/default");
-        clientExecutor.setHttpMethod("GET");
-        ClientResponse serverResponse = clientExecutor.execute();
-
-        final String respBodyAsString = (String)serverResponse.getEntity(String.class);
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target("http://localhost:9073/identitymanagement-services/identitymanagement-services/person/internalHandle/person_id_009/biographics/default");
+        Response response = target.request().get();
+        final String respBodyAsString = response.readEntity(String.class);
         JSONAssert.assertEquals(jsonBodyRequest, respBodyAsString, true);
 
         System.out.println("### bio response from mapping: \n" + respBodyAsString);

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMockerTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/mocker/RestEndPointMockerTest.java
@@ -15,9 +15,11 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.jboss.resteasy.client.ClientRequest;
-import org.jboss.resteasy.client.ClientResponse;
-import org.jboss.resteasy.client.core.executors.ApacheHttpClientExecutor;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 import org.jsmart.zerocode.core.di.main.ApplicationMainModule;
 import org.jsmart.zerocode.core.domain.MockStep;
 import org.jsmart.zerocode.core.domain.MockSteps;
@@ -126,12 +128,10 @@ public class RestEndPointMockerTest {
                         .withHeader("Content-Type", APPLICATION_JSON)
                         .withBody(jsonBodyRequest)));
 
-        ApacheHttpClientExecutor httpClientExecutor = new ApacheHttpClientExecutor();
-        ClientRequest clientExecutor = httpClientExecutor.createRequest("http://localhost:9073" + mockStep.getUrl());
-        clientExecutor.setHttpMethod("GET");
-        ClientResponse serverResponse = clientExecutor.execute();
-
-        final String respBodyAsString = (String) serverResponse.getEntity(String.class);
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target("http://localhost:9073" + mockStep.getUrl());
+        Response response = target.request().get();
+        final String respBodyAsString = response.readEntity(String.class);
         JSONAssert.assertEquals(jsonBodyRequest, respBodyAsString, true);
 
         System.out.println("### zerocode: \n" + respBodyAsString);

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,8 @@
         <guice.version>7.0.0</guice.version>
         <commons-lang.version>2.6</commons-lang.version>
         <jayway-version>2.2.0</jayway-version>
-        <resteasy-jaxrs.version>2.2.1.GA</resteasy-jaxrs.version>
+        <!-- resteasy 4.7.0.Final needs JDK11 -->
+        <resteasy-jaxrs.version>3.15.6.Final</resteasy-jaxrs.version>
         <!-- logback 1.4.x and 1.5.x need JDK11 -->
         <logback.version>1.3.14</logback.version>
         <slf4j.version>2.0.12</slf4j.version>
@@ -187,6 +188,12 @@
                 <artifactId>resteasy-jaxrs</artifactId>
                 <version>${resteasy-jaxrs.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-client</artifactId>
+                <version>${resteasy-jaxrs.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <junit.vintage.version>5.4.2</junit.vintage.version>
         <junit-platform-runner.version>1.4.2</junit-platform-runner.version>
         <junit.version>4.13.2</junit.version>
-        <jackson-databind.version>2.15.4</jackson-databind.version>
+        <jackson.version>2.15.4</jackson.version>
         <guava.version>33.0.0-jre</guava.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <classpath-explorer.version>1.0</classpath-explorer.version>
@@ -77,7 +77,6 @@
         <logback.version>1.3.14</logback.version>
         <slf4j.version>2.0.12</slf4j.version>
         <wiremock.version>2.19.0</wiremock.version>
-        <jackson-dataformat-csv.version>2.9.8</jackson-dataformat-csv.version>
         <commons-io.version>2.15.0</commons-io.version>
         <micro-simulator.version>1.1.10</micro-simulator.version>
         <httpclient.version>4.5</httpclient.version>
@@ -150,12 +149,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${jackson-dataformat-csv.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-csv</artifactId>
-                <version>${jackson-dataformat-csv.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -226,22 +225,22 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
# Upgrade jackson 2.15.4 and resteasy 3.15.6.Final

## Fixes Issue
- [x] Which issue or ticket was(will be) fixed in this PR? partially fixes https://github.com/authorjapps/zerocode/issues/607

PR Branch
https://github.com/baulea/zerocode/tree/upgrade_jackson_resteasy

## Motivation and Context

- upgrade multiple maven dependencies for later Java17 compatibility, Issue https://github.com/authorjapps/zerocode/issues/607
- consolidate all Jackson artifacts to version 2.15.4
- fix vulnerabilities [CVE-2016-6346](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6346) and [CVE-2014-7839](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7839)

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [x] Test names are meaningful

* [x] Feature manually tested

* [x] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [x] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
