### PR TITLE
introduce JsonPathJacksonProvider

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -110,10 +110,6 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>com.google.classpath-explorer</groupId>

--- a/core/src/main/java/org/jsmart/zerocode/core/di/provider/JsonPathJacksonProvider.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/provider/JsonPathJacksonProvider.java
@@ -1,0 +1,37 @@
+package org.jsmart.zerocode.core.di.provider;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import jakarta.inject.Provider;
+import java.util.EnumSet;
+import java.util.Set;
+
+public class JsonPathJacksonProvider implements Provider<Configuration.Defaults> {
+    @Override
+    public Configuration.Defaults get() {
+        return new Configuration.Defaults() {
+
+            private final JsonProvider jsonProvider = new JacksonJsonProvider();
+            private final MappingProvider mappingProvider = new JacksonMappingProvider();
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return jsonProvider;
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return mappingProvider;
+            }
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+        };
+    }
+}

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/array/ArrayIsEmptyAsserterImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/array/ArrayIsEmptyAsserterImpl.java
@@ -1,9 +1,10 @@
 
 package org.jsmart.zerocode.core.engine.assertion.array;
 
-import net.minidev.json.JSONArray;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
 import org.jsmart.zerocode.core.engine.assertion.JsonAsserter;
+
+import java.util.List;
 
 import static org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher.aMatchingMessage;
 import static org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher.aNotMatchingMessage;
@@ -27,21 +28,14 @@ public class ArrayIsEmptyAsserterImpl implements JsonAsserter {
 
     @Override
     public FieldAssertionMatcher actualEqualsToExpected(Object result) {
-        if(result instanceof JSONArray){
+        if (result instanceof List<?>) {
+            List<?> list = (List<?>) result;
 
-            final JSONArray actualArrayValue = (JSONArray) result;
-
-            if(actualArrayValue.isEmpty()){
-
+            if (list.isEmpty()) {
                 return aMatchingMessage();
             }
 
-            return aNotMatchingMessage(path, "[]", result);
-
-        } else {
-
-            return aNotMatchingMessage(path, "[]", result);
-
         }
+        return aNotMatchingMessage(path, "[]", result);
     }
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/array/ArraySizeAsserterImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/array/ArraySizeAsserterImpl.java
@@ -1,9 +1,10 @@
 
 package org.jsmart.zerocode.core.engine.assertion.array;
 
-import net.minidev.json.JSONArray;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
 import org.jsmart.zerocode.core.engine.assertion.JsonAsserter;
+
+import java.util.List;
 
 import static org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher.aMatchingMessage;
 import static org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher.aNotMatchingMessage;
@@ -41,17 +42,16 @@ public class ArraySizeAsserterImpl implements JsonAsserter {
 
     @Override
     public FieldAssertionMatcher actualEqualsToExpected(Object result) {
-        if (result instanceof JSONArray) {
-
-            final JSONArray actualArrayValue = (JSONArray) result;
+        if (result instanceof List<?>) {
+            List<?> list = (List<?>) result;
 
             if (this.expectedSize == -1 && this.expectedSizeExpression != null) {
 
-                return processRelationalExpression(actualArrayValue);
+                return processRelationalExpression(list);
 
             }
 
-            if (actualArrayValue.size() == this.expectedSize) {
+            if (list.size() == this.expectedSize) {
 
                 return aMatchingMessage();
             }
@@ -59,7 +59,7 @@ public class ArraySizeAsserterImpl implements JsonAsserter {
             return aNotMatchingMessage(
                     path,
                     String.format("Array of size %d", expectedSize),
-                    actualArrayValue.size());
+                    list.size());
 
         } else {
 
@@ -68,25 +68,25 @@ public class ArraySizeAsserterImpl implements JsonAsserter {
         }
     }
 
-    public FieldAssertionMatcher processRelationalExpression(JSONArray actualArrayValue) {
+    public FieldAssertionMatcher processRelationalExpression(List<?> list) {
         if (expectedSizeExpression.startsWith(ASSERT_VALUE_GREATER_THAN)) {
             String greaterThan = this.expectedSizeExpression.substring(ASSERT_VALUE_GREATER_THAN.length());
-            if (actualArrayValue.size() > Integer.parseInt(greaterThan)) {
+            if (list.size() > Integer.parseInt(greaterThan)) {
                 return aMatchingMessage();
             }
         } else if (expectedSizeExpression.startsWith(ASSERT_VALUE_LESSER_THAN)) {
             String lesserThan = this.expectedSizeExpression.substring(ASSERT_VALUE_LESSER_THAN.length());
-            if (actualArrayValue.size() < Integer.parseInt(lesserThan)) {
+            if (list.size() < Integer.parseInt(lesserThan)) {
                 return aMatchingMessage();
             }
         } else if (expectedSizeExpression.startsWith(ASSERT_VALUE_EQUAL_TO_NUMBER)) {
             String equalTo = this.expectedSizeExpression.substring(ASSERT_VALUE_EQUAL_TO_NUMBER.length());
-            if (actualArrayValue.size() == Integer.parseInt(equalTo)) {
+            if (list.size() == Integer.parseInt(equalTo)) {
                 return aMatchingMessage();
             }
         } else if (expectedSizeExpression.startsWith(ASSERT_VALUE_NOT_EQUAL_TO_NUMBER)) {
             String notEqualTo = this.expectedSizeExpression.substring(ASSERT_VALUE_NOT_EQUAL_TO_NUMBER.length());
-            if (actualArrayValue.size() != Integer.parseInt(notEqualTo)) {
+            if (list.size() != Integer.parseInt(notEqualTo)) {
                 return aMatchingMessage();
             }
         }
@@ -94,7 +94,7 @@ public class ArraySizeAsserterImpl implements JsonAsserter {
         return aNotMatchingMessage(
                 path,
                 String.format("Array of size %s", expectedSizeExpression),
-                actualArrayValue.size());
+                list.size());
     }
 
 

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImpl.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.jayway.jsonpath.JsonPath;
-import net.minidev.json.JSONArray;
 import org.apache.commons.text.StringSubstitutor;
 import org.jsmart.zerocode.core.domain.Step;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
@@ -442,7 +441,7 @@ public class ZeroCodeAssertionsProcessorImpl implements ZeroCodeAssertionsProces
     }
 
     boolean isPathValueJson(Object jsonPathValue) {
-        return jsonPathValue instanceof LinkedHashMap || jsonPathValue instanceof JSONArray;
+        return jsonPathValue instanceof LinkedHashMap || jsonPathValue instanceof List<?>;
     }
 
     void resolveLeafOnlyNodeValue(String scenarioState, Map<String, String> paramMap, String thisPath) {

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/validators/ZeroCodeValidatorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/validators/ZeroCodeValidatorImpl.java
@@ -1,16 +1,22 @@
 package org.jsmart.zerocode.core.engine.validators;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
+import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
-import java.util.ArrayList;
-import java.util.List;
+import org.jsmart.zerocode.core.di.provider.JsonPathJacksonProvider;
+import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.jsmart.zerocode.core.domain.Step;
 import org.jsmart.zerocode.core.domain.Validator;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
 import org.jsmart.zerocode.core.engine.assertion.JsonAsserter;
 import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeAssertionsProcessor;
 import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.jsmart.zerocode.core.utils.HelperJsonUtils.strictComparePayload;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -20,9 +26,13 @@ public class ZeroCodeValidatorImpl implements ZeroCodeValidator {
 
     private final ZeroCodeAssertionsProcessor zeroCodeAssertionsProcessor;
 
+    private final ObjectMapper mapper;
+
     @Inject
     public ZeroCodeValidatorImpl(ZeroCodeAssertionsProcessor zeroCodeAssertionsProcessor) {
         this.zeroCodeAssertionsProcessor = zeroCodeAssertionsProcessor;
+        this.mapper = new ObjectMapperProvider().get();
+        Configuration.setDefaults(new JsonPathJacksonProvider().get());
     }
 
     @Override
@@ -40,10 +50,16 @@ public class ZeroCodeValidatorImpl implements ZeroCodeValidator {
             JsonNode expectedValue = validator.getValue();
 
             Object actualValue = JsonPath.read(actualResult, transformed);
+            String actualString;
+            try {
+                actualString = this.mapper.writeValueAsString(actualValue);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
 
             List<JsonAsserter> asserters = zeroCodeAssertionsProcessor.createJsonAsserters(expectedValue.toString());
 
-            failureResults.addAll(zeroCodeAssertionsProcessor.assertAllAndReturnFailed(asserters, actualValue.toString()));
+            failureResults.addAll(zeroCodeAssertionsProcessor.assertAllAndReturnFailed(asserters, actualString));
         }
 
         return failureResults;

--- a/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaProducerHelper.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/kafka/helper/KafkaProducerHelper.java
@@ -1,17 +1,14 @@
 package org.jsmart.zerocode.core.kafka.helper;
 
-import static org.jsmart.zerocode.core.kafka.KafkaConstants.RAW;
-import static org.jsmart.zerocode.core.kafka.common.CommonConfigs.BOOTSTRAP_SERVERS;
-import static org.jsmart.zerocode.core.kafka.common.KafkaCommonUtils.resolveValuePlaceHolders;
-import static org.jsmart.zerocode.core.kafka.error.KafkaMessageConstants.NO_RECORD_FOUND_TO_SEND;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Properties;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.Message.Builder;
+import com.google.protobuf.util.JsonFormat;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -22,15 +19,17 @@ import org.jsmart.zerocode.core.kafka.send.message.ProducerJsonRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.Resources;
-import com.google.gson.Gson;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Message;
-import com.google.protobuf.Message.Builder;
-import com.google.protobuf.util.JsonFormat;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.PathNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Properties;
+
+import static org.jsmart.zerocode.core.kafka.KafkaConstants.RAW;
+import static org.jsmart.zerocode.core.kafka.common.CommonConfigs.BOOTSTRAP_SERVERS;
+import static org.jsmart.zerocode.core.kafka.common.KafkaCommonUtils.resolveValuePlaceHolders;
+import static org.jsmart.zerocode.core.kafka.error.KafkaMessageConstants.NO_RECORD_FOUND_TO_SEND;
 
 public class KafkaProducerHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProducerHelper.class);

--- a/core/src/test/java/org/jsmart/zerocode/converter/MimeTypeConverterTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/converter/MimeTypeConverterTest.java
@@ -2,30 +2,33 @@ package org.jsmart.zerocode.converter;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
+import org.jsmart.zerocode.core.di.provider.JsonPathJacksonProvider;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.apache.commons.text.StringEscapeUtils.escapeJava;
 import static org.apache.commons.text.StringEscapeUtils.escapeEcmaScript;
+import static org.apache.commons.text.StringEscapeUtils.escapeJava;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MimeTypeConverterTest {
 
-    private ObjectMapper mapper = new ObjectMapperProvider().get();
+    private final ObjectMapper mapper = new ObjectMapperProvider().get();
 
     private Converter xmlToJsonConverter;
 
     @Before
-    public void setUpStuffs() throws Exception {
+    public void setUpStuffs() {
         xmlToJsonConverter = new MimeTypeConverter(mapper);
+        Configuration.setDefaults(new JsonPathJacksonProvider().get());
     }
 
     @Test
-    public void testXmlToJsonWithSingleQuote_willNotFail() throws Exception {
+    public void testXmlToJsonWithSingleQuote_willNotFail() {
 
         String xml = "<?xml version='1.0' encoding=\"UTF-8\"?><address>Street 123</address>";
         String escapedOut = escapeEcmaScript(xml);
@@ -180,12 +183,12 @@ public class MimeTypeConverterTest {
                 "            }\n" +
                 "        }";
 
-        String jsonArrayString = JsonPath.read(jsonBlockString, "$.addresses.address").toString();
-        System.out.println("--- jsonArray: \n" + jsonArrayString);
+        Object jsonPathValue = JsonPath.read(jsonBlockString, "$.addresses.address");
+        System.out.println("--- jsonArray: \n" + jsonPathValue.toString());
 
-        JsonNode jsonNodeInput = mapper.readTree(jsonArrayString);
+        JsonNode jsonNodeInput = this.mapper.valueToTree(jsonPathValue);
 
-        Object jsonNodeOutput = xmlToJsonConverter.jsonBlockToJson(jsonNodeInput);
+        Object jsonNodeOutput = this.xmlToJsonConverter.jsonBlockToJson(jsonNodeInput);
 
         System.out.println("--- jsonArrayBlockOutput:\n" + jsonNodeOutput);
 

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/sorter/ZeroCodeSorterImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/sorter/ZeroCodeSorterImplTest.java
@@ -3,7 +3,9 @@ package org.jsmart.zerocode.core.engine.sorter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.jayway.jsonpath.Configuration;
 import org.jsmart.zerocode.core.di.main.ApplicationMainModule;
+import org.jsmart.zerocode.core.di.provider.JsonPathJacksonProvider;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
 import org.jsmart.zerocode.core.domain.Step;
@@ -30,6 +32,7 @@ public class ZeroCodeSorterImplTest {
         injector = Guice.createInjector(new ApplicationMainModule(serverEnvFileName));
         smartUtils = injector.getInstance(SmartUtils.class);
         mapper = new ObjectMapperProvider().get();
+        Configuration.setDefaults(new JsonPathJacksonProvider().get());
         jsonPreProcessor =
                 new ZeroCodeAssertionsProcessorImpl(smartUtils.getMapper(), serverEnvFileName);
 
@@ -64,7 +67,7 @@ public class ZeroCodeSorterImplTest {
                 "}\n";
 
         String result = sorter.sortArrayAndReplaceInResponse(step, response, scenarioExecutionState.getResolvedScenarioState());
-        JSONAssert.assertEquals(sortedResponse, result, false);
+        JSONAssert.assertEquals(sortedResponse, result, true);
     }
 
     @Test
@@ -94,7 +97,7 @@ public class ZeroCodeSorterImplTest {
                 "}\n";
 
         String result = sorter.sortArrayAndReplaceInResponse(step, response, scenarioExecutionState.getResolvedScenarioState());
-        JSONAssert.assertEquals(sortedResponse, result, false);
+        JSONAssert.assertEquals(sortedResponse, result, true);
     }
 
     @Test
@@ -124,7 +127,7 @@ public class ZeroCodeSorterImplTest {
                 "}\n";
 
         String result = sorter.sortArrayAndReplaceInResponse(step, response, scenarioExecutionState.getResolvedScenarioState());
-        JSONAssert.assertEquals(sortedResponse, result, false);
+        JSONAssert.assertEquals(sortedResponse, result, true);
     }
 
 }

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/validators/ZeroCodeValidatorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/validators/ZeroCodeValidatorImplTest.java
@@ -3,10 +3,10 @@ package org.jsmart.zerocode.core.engine.validators;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.Is.is;
+import com.jayway.jsonpath.Configuration;
 import org.jsmart.zerocode.TestUtility;
 import org.jsmart.zerocode.core.di.main.ApplicationMainModule;
+import org.jsmart.zerocode.core.di.provider.JsonPathJacksonProvider;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
 import org.jsmart.zerocode.core.domain.Step;
@@ -15,11 +15,14 @@ import org.jsmart.zerocode.core.engine.preprocessor.ScenarioExecutionState;
 import org.jsmart.zerocode.core.engine.preprocessor.StepExecutionState;
 import org.jsmart.zerocode.core.engine.preprocessor.ZeroCodeAssertionsProcessorImpl;
 import org.jsmart.zerocode.core.utils.SmartUtils;
-import static org.junit.Assert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class ZeroCodeValidatorImplTest {
     Injector injector;
@@ -36,6 +39,9 @@ public class ZeroCodeValidatorImplTest {
         injector = Guice.createInjector(new ApplicationMainModule(serverEnvFileName));
         smartUtils = injector.getInstance(SmartUtils.class);
         mapper = new ObjectMapperProvider().get();
+        Configuration.setDefaults(new JsonPathJacksonProvider().get());
+
+
         jsonPreProcessor =
                 new ZeroCodeAssertionsProcessorImpl(smartUtils.getMapper(), serverEnvFileName);
 

--- a/pom.xml
+++ b/pom.xml
@@ -203,11 +203,6 @@
                 <artifactId>json-path</artifactId>
                 <version>${jayway-version}</version>
             </dependency>
-            <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>${json-smart.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>com.google.classpath-explorer</groupId>


### PR DESCRIPTION
# <Feature Title>

## Fixes Issue
- [x] Which issue or ticket was(will be) fixed in this PR?  https://github.com/authorjapps/zerocode/issues/648

PR Branch
https://github.com/baulea/zerocode/tree/jsonPathJacksonProvider

## Motivation and Context
Move to jackson json provider in JsonPath instead of jsonsmart. Jackson is already used in zerocode, and we can get rid of jsonsmart as another JSON processor.

## Checklist:

* [ ] Unit tests added

* [ ] Integration tests added

* [x] Test names are meaningful

* [x] Feature manually tested

* [ ] Branch build passed

* [x] No 'package.*' in the imports

* [ ] Relevant Wiki page updated with clear instruction for the end user
  * [x] Not applicable. This was only a refactor change, no functional or behaviour changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
