### PR TITLE
Fixed flaky test-case: ConsumerJsonRecordTest.should_serialize_a_record_with_headers

### DIFF
--- a/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/kafka/receive/message/ConsumerJsonRecordTest.java
@@ -9,7 +9,7 @@ import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,7 +49,7 @@ public class ConsumerJsonRecordTest {
         // given
         JsonNode key = objectMapper.readTree("123");
         JsonNode value = objectMapper.readTree("\"val\"");
-        Map<String, String> headers = new HashMap<>();
+        Map<String, String> headers = new LinkedHashMap<>();
         headers.put("hKey", "hValue");
         headers.put("hKeyWithNullValue", null);
         ConsumerJsonRecord record = new ConsumerJsonRecord(key, value, headers);


### PR DESCRIPTION
# Fixed flaky test-case

## Fixes Issue
- [x] Which issue or ticket was(will be) fixed by this PR? 
authorjapps/zerocode/issues/685

PR Branch
**[fork](https://github.com/hermya/zerocode)**

## Motivation and Context
ConsumerJsonRecordTest.should_serialize_a_record_with_headers is a flaky test, fixed in this PR.

POINT OF FAILURE -> random attribute ordering in hashmap
Fixed using NonDex pugin
Suggested command to check all flaky tests :
> mvn nondex:nondex

For particular test:
Add the following lines to your pom.xml
```
  <plugin> <!-- for flaky testing -->
      <groupId>edu.illinois</groupId>
      <artifactId>nondex-maven-plugin</artifactId>
      <version>2.1.7</version>
  </plugin>
```
and run
>mvn -pl ./core nondex:nondex -Dtest=org.jsmart.zerocode.core.kafka.receive.message.ConsumerJsonRecordTest#should_serialize_a_record_with_headers -DnondexRuns=10

**OR**

>mvn -pl ./core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.jsmart.zerocode.core.kafka.receive.message.ConsumerJsonRecordTest#should_serialize_a_record_with_headers -DnondexRuns=10

For more information : https://github.com/TestingResearchIllinois/NonDex

## Checklist:

* [ ] New Unit tests were added
  * [ ] Covered in existing Unit tests

* [ ] Integration tests were added
  * [ ] Covered in existing Integration tests

* [ ] Test names are meaningful

* [ ] Feature manually tested and outcome is successful

* [X] PR doesn't break any of the earlier features for end users
  * [ ] WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [X] Branch build passed in CI

* [X] No 'package.*' in the imports

* [ ] Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [X] Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [X] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [X] Not applicable. The changes did not affect Kafka automation flow
