### PR TITLE
ISSUE-688 # Propagate exceptions from java api operations

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/AddService.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/AddService.java
@@ -21,6 +21,12 @@ public class AddService {
         return myNumber.getNumber() * myNumber.getNumber();
     }
 
+    public Double squareRoot(Double number) {
+    	if (number < 0.0)
+    		throw new RuntimeException("Can not square root a negative number");
+        return Math.sqrt(number);
+    }
+    
     public Integer anInteger() {
         logger.debug("Returning a number ");
 

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/executor/javaapi/JavaMethodExecutorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/executor/javaapi/JavaMethodExecutorImpl.java
@@ -111,7 +111,7 @@ public class JavaMethodExecutorImpl implements JavaMethodExecutor {
         } catch (Exception e) {
             String errMsg = format("Java exec(): Invocation failed for method %s in class %s", methodName, qualifiedClassName);
             LOGGER.error(errMsg + ". Exception - " + e);
-            throw new RuntimeException(errMsg);
+            throw new RuntimeException(errMsg, e);
         }
     }
 

--- a/core/src/test/resources/unit_test_files/java_apis/03_test_json_java_service_method_Exception.json
+++ b/core/src/test/resources/unit_test_files/java_apis/03_test_json_java_service_method_Exception.json
@@ -1,0 +1,13 @@
+{
+  "scenarioName": "Given_When_Then-Flow name For Java Service",
+  "steps": [
+    {
+      "name": "javaMethodException",
+      "url": "org.jsmart.zerocode.core.AddService",
+      "operation": "squareRoot",
+      "request": "-255.0", //<-- This negative number should throw an exception
+      "assertions": {
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Propagate exceptions from java api operations

## Fixes Issue
- [x] Which issue or ticket was(will be) fixed by this PR? Fix #688 

PR Branch
**https://github.com/javiertuya/zerocode/tree/688-exceptions-java-api**

## Motivation and Context

When executing a java method that is invoked by the java api as an operation, any exception in the java method should be shown in the stacktrace to facilitate debugging. The executor exception handler should include this exception

## Checklist:

* [x] New Unit tests were added
  * [ ] Covered in existing Unit tests

* [ ] Integration tests were added
  * [ ] Covered in existing Integration tests

* [x] Test names are meaningful

* [x] Feature manually tested and outcome is successful

* [x] PR doesn't break any of the earlier features for end users
  * [ ] WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [x] Branch build passed in CI

* [x] No 'package.*' in the imports

* [ ] Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [x] Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
