### PR TITLE
Add theme toggle in HTML report

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/constants/ZeroCodeReportConstants.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/constants/ZeroCodeReportConstants.java
@@ -25,5 +25,5 @@ public interface ZeroCodeReportConstants {
     String EXTENT_ADDITIONAL_JS = "document.querySelector('.vheader').insertAdjacentHTML('afterbegin'," +
             "'<div id=\"theme-selector\"class=\"nav-right\"onClick=$(\"body\").toggleClass(\"dark\")>" +
             "<span class=\"badge badge-primary\"><i class=\"fa fa-desktop\"></i></span></div>')";
-    String EXTENT_ADDITIONAL_CSS = "#theme-selector{margin-right:15px}";
+    String EXTENT_ADDITIONAL_CSS = "#theme-selector{padding-right:12px;padding-left:12px;margin-right:10px}";
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/constants/ZeroCodeReportConstants.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/constants/ZeroCodeReportConstants.java
@@ -22,6 +22,8 @@ public interface ZeroCodeReportConstants {
     String CHARTS_AND_CSV = "gen-smart-charts-csv-reports";
 
     // Custom js and css for extent report
-    String EXTENT_ADDITIONAL_JS = "document.write('<div id=\"theme-selector\"onClick=$(\"body\").toggleClass(\"dark\")><span><i class=\"fa fa-desktop\"></i></span></div>')";
-    String EXTENT_ADDITIONAL_CSS = "#theme-selector{cursor:pointer;position:fixed;bottom:10px;left:25px;z-index:9999;}";
+    String EXTENT_ADDITIONAL_JS = "document.querySelector('.vheader').insertAdjacentHTML('afterbegin'," +
+            "'<div id=\"theme-selector\"class=\"nav-right\"onClick=$(\"body\").toggleClass(\"dark\")>" +
+            "<span class=\"badge badge-primary\"><i class=\"fa fa-desktop\"></i></span></div>')";
+    String EXTENT_ADDITIONAL_CSS = "#theme-selector{margin-right:15px}";
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/constants/ZeroCodeReportConstants.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/constants/ZeroCodeReportConstants.java
@@ -21,4 +21,7 @@ public interface ZeroCodeReportConstants {
     String ZEROCODE_JUNIT = "zerocode.junit";
     String CHARTS_AND_CSV = "gen-smart-charts-csv-reports";
 
+    // Custom js and css for extent report
+    String EXTENT_ADDITIONAL_JS = "document.write('<div id=\"theme-selector\"onClick=$(\"body\").toggleClass(\"dark\")><span><i class=\"fa fa-desktop\"></i></span></div>')";
+    String EXTENT_ADDITIONAL_CSS = "#theme-selector{cursor:pointer;position:fixed;bottom:10px;left:25px;z-index:9999;}";
 }

--- a/core/src/main/java/org/jsmart/zerocode/core/domain/builders/ExtentReportsFactory.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/domain/builders/ExtentReportsFactory.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.jsmart.zerocode.core.constants.ZeroCodeReportConstants.EXTENT_ADDITIONAL_CSS;
+import static org.jsmart.zerocode.core.constants.ZeroCodeReportConstants.EXTENT_ADDITIONAL_JS;
 import static org.jsmart.zerocode.core.constants.ZeroCodeReportConstants.REPORT_DISPLAY_NAME_DEFAULT;
 import static org.jsmart.zerocode.core.constants.ZeroCodeReportConstants.REPORT_TITLE_DEFAULT;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -56,7 +58,8 @@ public class ExtentReportsFactory {
     public static ExtentSparkReporter createExtentHtmlReporter(String reportFileName) {
         extentSparkReporter = new ExtentSparkReporter(reportFileName);
 
-
+        extentSparkReporter.config().setJs(EXTENT_ADDITIONAL_JS);
+        extentSparkReporter.config().setCss(EXTENT_ADDITIONAL_CSS);
         extentSparkReporter.config().setDocumentTitle(REPORT_TITLE_DEFAULT);
         extentSparkReporter.config().setReportName(REPORT_DISPLAY_NAME_DEFAULT);
 


### PR DESCRIPTION
# Add theme toggle in HTML report

## Fixes Issue
- [x] https://github.com/authorjapps/zerocode/issues/694

PR Branch
https://github.com/bppdanto-t/zerocode/tree/add-theme-toggle

## Motivation and Context
Due to version update of `extentreport` library, the toggle theme icon is missing from the HTML report. While toggling the theme is still achievable by pressing "L" key with keyboard, there's not much visibility to the user on how to do it. This PR will add the toggle icon back and move it to the top right side, as requested by @authorjapps ([comment link](https://github.com/authorjapps/zerocode/issues/694#issuecomment-2506364661)).

Light theme
<img width="1795" alt="image" src="https://github.com/user-attachments/assets/bd6c3299-8672-4a04-a229-8d48f64baf48">

Dark theme
<img width="1795" alt="image" src="https://github.com/user-attachments/assets/d47ae4c3-099a-4cb5-8be8-344d28e56089">


## Checklist:

* [ ] New Unit tests were added
  * [ ] Covered in existing Unit tests

* [ ] Integration tests were added
  * [ ] Covered in existing Integration tests

* [ ] Test names are meaningful

* [x] Feature manually tested and outcome is successful

* [x] PR doesn't break any of the earlier features for end users
  * [ ] WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [x] Branch build passed in CI

* [x] No 'package.*' in the imports

* [ ] Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [x] Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
