### PR TITLE
Add GitHub Actions workflow to verify flaky test

### DIFF
--- a/.github/workflows/verify-flaky-test.yml
+++ b/.github/workflows/verify-flaky-test.yml
@@ -1,0 +1,60 @@
+name: Verify Flaky Test
+
+on:
+  push:
+    branches: [ verify-flaky-test ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          
+      - name: Build with Maven (Skip Tests)
+        run: mvn clean install -DskipTests
+        
+      - name: Run Test Normally (Expected to Pass)
+        run: |
+          echo "Running test without NonDex - should PASS"
+          mvn test -pl core -Dtest=org.jsmart.zerocode.core.kafka.DeliveryDetailsTest#testSerDeser
+          echo "Test passed without NonDex as expected"
+          
+      - name: Run Test with NonDex (Expected to Fail)
+        continue-on-error: true
+        id: nondex-run
+        run: |
+          echo "Running test with NonDex - should FAIL"
+          mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl core -Dtest=org.jsmart.zerocode.core.kafka.DeliveryDetailsTest#testSerDeser
+          # Store the exit code
+          echo "nondex_exit_code=$?" >> $GITHUB_OUTPUT
+          
+      - name: Display NonDex Results
+        run: |
+          echo "Checking NonDex results"
+          ls -la core/.nondex/ || echo "No .nondex directory found"
+          for dir in core/.nondex/*/; do
+            if [ -d "$dir" ]; then
+              echo "Contents of $dir:"
+              ls -la "$dir"
+              if [ -f "$dir/failure" ]; then
+                echo "Found failure file in $dir:"
+                cat "$dir/failure"
+              fi
+            fi
+          done
+          
+      - name: Verify Test Flakiness
+        run: |
+          if [ "${{ steps.nondex-run.outputs.nondex_exit_code }}" != "0" ]; then
+            echo "✅ Test is flaky: Passes without NonDex but fails with NonDex"
+          else
+            echo "❌ Test is not flaky: Passes both with and without NonDex"
+            exit 1
+          fi


### PR DESCRIPTION
## Purpose

This PR adds a custom GitHub Actions workflow named `verify-flaky-test.yml` to confirm that the test `org.jsmart.zerocode.core.kafka.DeliveryDetailsTest#testSerDeser` is flaky. The test passes under normal execution but fails when executed with NonDex, confirming the presence of non-deterministic behavior.

## Summary of Changes

- Added a new workflow `.github/workflows/verify-flaky-test.yml`
- The workflow:
  - Sets up JDK 11 using `actions/setup-java`
  - Builds the project using Maven with tests skipped
  - Runs the test once normally (expected to pass)
  - Runs the test again using NonDex (expected to fail)
  - Verifies flakiness by comparing exit codes and logs

## Output

The GitHub Actions build shows:
- ✅ Normal test run passes
- ❌ NonDex test run fails
- ✅ Final verification logs include:  
  `✅ Test is flaky: Passes without NonDex but fails with NonDex`

You can find the logs and output in the attached file or view the successful build here:
[https://github.com/Md-Arif-Hasan/zerocode/actions/runs/14678327187/job/41197758983](url)

## Attachments

- 🔗 CI Build Log: `logs_37716316986.zip` (see `ci-build.log`)
- 🧾 Workflow YAML: `.github/workflows/verify-flaky-test.yml`
- 🔄 Diff: Use `git diff` to compare this new file against the baseline

## Notes

This workflow documents the flakiness of DeliveryDetailsTest.testSerDeser using GitHub Actions.
The CI logs confirm that the test passes normally but fails under NonDex shuffling.
