### PR TITLE
Build multiple JDKs and junit test reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,18 @@ on:
       - master
 jobs:
   build:
+    strategy:
+      matrix:
+        version: [8, 11, 17, 21, 23]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setting up JDK8
+      - name: Setting up JDK ${{ matrix.version }}
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: "${{ matrix.version }}"
           distribution: 'adopt'
 
       - name: Install Docker Compose
@@ -33,3 +37,18 @@ jobs:
 
       - name: Building and testing the changes
         run: mvn clean test
+
+      - if: always()
+        name: Junit html report
+        uses: javiertuya/junit-report-action@v1.3.0
+        with:
+          surefire-files: "**/target/surefire-reports/TEST-*.xml"
+          report-dir: target/site/junit
+
+      - if: always()
+        name: Publish test report files
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: "test-report-java${{ matrix.version }}"
+          path: |
+            target/site/junit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,11 @@ jobs:
         uses: javiertuya/junit-report-action@v1.3.0
         with:
           surefire-files: "**/target/surefire-reports/TEST-*.xml"
-          report-dir: target/site/junit
+          report-dir: target/reports
+
+      - if: always()
+        name: Interactive and granular reports
+        run: cp core/target/*.html target/reports/ && cp core/target/*.csv target/reports/
 
       - if: always()
         name: Publish test report files
@@ -47,4 +51,5 @@ jobs:
         with:
           name: "test-report-java${{ matrix.version }}"
           path: |
-            target/site/junit
+            target/reports
+            !target/reports/someFileName.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,27 +16,23 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setting up JDK ${{ matrix.version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: "${{ matrix.version }}"
-          distribution: 'adopt'
+          distribution: 'temurin'
+          cache: 'maven'
 
-      - name: Install Docker Compose
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
-          
       - name: Running Kafka
-        run: docker-compose -f docker/compose/kafka-schema-registry.yml up -d && sleep 10
+        run: docker compose -f docker/compose/kafka-schema-registry.yml up -d && sleep 10
 
       - name: Running PostgreSQL (to test DB SQL Executor)
-        run: docker-compose -f docker/compose/pg_compose.yml up -d
+        run: docker compose -f docker/compose/pg_compose.yml up -d
 
       - name: Building and testing the changes
-        run: mvn clean test
+        run: mvn clean test -ntp
 
       - if: always()
         name: Junit html report


### PR DESCRIPTION
# <Feature Title>

## Fixed Which Issue?
- [x] Which issue or ticket was(will be) fixed by this PR? Close #714

PR Branch
[javiertuya:714-multiple-jdks](https://github.com/javiertuya/zerocode/tree/714-multiple-jdks)

## Motivation and Context

After merging #713 the build supports Java versions from 8 to 23, but future changes could break compatibility if no tested in CI. This PR includes:
- Use a matrix strategy to run the workflow on all LTS JDK versions (8,11,17,21) and the latest (23)
- Add downloadable junit test reports
- Workflow updates (java distribution, actions, docker compose, maven cache)

## Checklist:

* [ ] New Unit tests were added
  * [x] Covered in existing Unit tests

* [ ] Integration tests were added
  * [x] Covered in existing Integration tests

* [ ] Test names are meaningful

* [ ] Feature manually tested and outcome is successful

* [x] PR doesn't break any of the earlier features for end users
  * [ ] WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [x] PR doesn't break the HTML report features directly
  * [ ] Yes! I've manually run it locally and seen the HTML reports are generated perfectly fine
  * [x] Yes! I've opened the generated HTML reports from the `/target` folder and they look fine

* [x] PR doesn't break any HTML report features indirectly
  * [x] I have not added or amended any dependencies in this PR
  * [ ] I have double checked, the new dependency added or removed has not affected the report generation indirectly
  * [x] Yes! I've seen the Sample report screenshots [here](https://github.com/authorjapps/zerocode/issues/694#issuecomment-2505958433), and HTML report of the current PR looks simillar.

* [x] Branch build passed in CI

* [ ] No 'package.*' in the imports

* [ ] Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [ ] Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] Http test added to `http-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect HTTP automation flow

* [ ] Kafka test added to `kafka-testing` module(if applicable) ?
  * [x] Not applicable. The changes did not affect Kafka automation flow
