### PR TITLE
Issue 722 # Execute tests from absolute path of a scenario file(Test only)

### DIFF
--- a/http-testing-examples/src/test/java/org/jsmart/zerocode/testhelp/tests/ScenarioAbsolutePathTest.java
+++ b/http-testing-examples/src/test/java/org/jsmart/zerocode/testhelp/tests/ScenarioAbsolutePathTest.java
@@ -1,0 +1,69 @@
+package org.jsmart.zerocode.testhelp.tests;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+import org.jsmart.zerocode.core.domain.Scenario;
+import org.jsmart.zerocode.core.domain.TargetEnv;
+import org.jsmart.zerocode.core.runner.ZeroCodeUnitRunner;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@TargetEnv("github_host.properties")
+@RunWith(ZeroCodeUnitRunner.class)
+public class ScenarioAbsolutePathTest {
+
+    // Trying in target folder
+    private static String folder1File1 = "target/temp/unit_test_files/cherry_pick_tests/folder_a/test_case_1.json";
+    private static String sourceResourceFile = "helloworld/hello_world_status_ok_assertions.json";
+
+    @BeforeClass
+    public static void start() {
+        System.out.println("INSIDE BEFORE");
+        Path path = Paths.get(folder1File1);
+        try {
+            Files.createDirectories(path.getParent());
+            String absolutePath = path.toFile().getAbsolutePath();
+            File f1 = new File(absolutePath);
+            f1.createNewFile();
+
+            InputStream resourceStream = Thread.currentThread()
+                    .getContextClassLoader()
+                    .getResourceAsStream(sourceResourceFile);
+            if (resourceStream == null) {
+                throw new FileNotFoundException(
+                        "Resource file '" + sourceResourceFile + "' not found in test resources.");
+            }
+
+            ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            int length;
+
+            while ((length = resourceStream.read(buffer)) != -1) {
+                outStream.write(buffer, 0, length);
+            }
+
+            String contents = outStream.toString("UTF-8");
+
+            Files.write(path, contents.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING);
+
+        } catch (IOException exx) {
+            throw new RuntimeException("Create file '" + folder1File1 + "' Exception" + exx);
+        }
+    }
+
+    @Test
+    @Scenario("target/temp/unit_test_files/cherry_pick_tests/folder_a/test_case_1.json")
+    public void testAbsolutePathGet() throws Exception {
+    }
+}


### PR DESCRIPTION

# Execute tests from absolute path of a scenario file

## Fixed Which Issue?
* Added a integration test for testing the usage of absolute path inside Scenario annotation

PR Branch
[https://github.com/poseidontor/zerocode/tree/absolute_path_scenario](https://github.com/poseidontor/zerocode/tree/absolute_path_scenario)

## Motivation and Context

## Checklist:

* [ ] 1. New Unit tests were added
  * [ ] 1.1 Covered in existing Unit tests

* [x] 2. Integration tests were added
  * [ ] 2.1 Covered in existing Integration tests

* [ ] 3. Test names are meaningful

* [ ] 3.1 Feature manually tested and outcome is successful

* [ ] 4. PR doesn't break any of the earlier features for end users
  * [ ] 4.1 WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [ ] 5. PR doesn't break the HTML report features directly
  * [ ] 5.1 Yes! I've manually run it locally and seen the HTML reports are generated perfectly fine
  * [ ] 5.2 Yes! I've opened the generated HTML reports from the `/target` folder and they look fine

* [ ] 6. PR doesn't break any HTML report features indirectly
  * [ ] 6.1 I have not added or amended any dependencies in this PR
  * [ ] 6.2 I have double checked, the new dependency added or removed has not affected the report generation indirectly
  * [ ] 6.3 Yes! I've seen the Sample report screenshots [here](https://github.com/authorjapps/zerocode/issues/694#issuecomment-2505958433), and HTML report of the current PR looks simillar.

* [ ] 7. Branch build passed in CI

* [ ] 8. No 'package.*' in the imports

* [ ] 9. Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [ ] 9.1 Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] 10. Http test added to `http-testing-examples` module(if applicable) ?
  * [ ] 10.1 Not applicable. The changes did not affect HTTP automation flow

* [ ] 11. Kafka test added to `kafka-testing-examples` module(if applicable) ?
  * [ ] 11.1 Not applicable. The changes did not affect Kafka automation flow
