### PR TITLE
Fix flaky test in BasicHttpClientTest

### DIFF
--- a/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.RequestBuilder;
@@ -47,7 +50,13 @@ public class BasicHttpClientTest {
         RequestBuilder requestBuilder = basicHttpClient.createRequestBuilder("/api/v1/founder", "POST", header, reqBodyAsString);
         String nameValuePairString = EntityUtils.toString(requestBuilder.getEntity(), "UTF-8");
         assertThat(requestBuilder.getMethod(), is("POST"));
-        assertThat(nameValuePairString, is("Company=Amazon&worthInBillion=999.999&age=30"));
+        Map<String, String> actualParams = Arrays.stream(nameValuePairString.split("&"))
+            .map(entry -> entry.split("=", 2))
+            .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));
+        
+        assertThat(actualParams.get("Company"), is("Amazon"));
+        assertThat(actualParams.get("age"), is("30"));
+        assertThat(actualParams.get("worthInBillion"), is("999.999"));
     }
 
     @Test
@@ -56,7 +65,12 @@ public class BasicHttpClientTest {
         String reqBodyAsString = "{\"Name\":\"Larry Pg\",\"Company\":\"Amazon\",\"Title\":\"CEO\"}";
         RequestBuilder requestBuilder = basicHttpClient.createRequestBuilder("/api/v1/founder", "POST", header, reqBodyAsString);
         String nameValuePairString = EntityUtils.toString(requestBuilder.getEntity(), "UTF-8");
-        assertThat(nameValuePairString, is("Company=Amazon&Title=CEO&Name=Larry+Pg"));
+        Map<String, String> actualParams = Arrays.stream(nameValuePairString.split("&"))
+            .map(entry -> entry.split("=", 2))
+            .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));  
+        assertThat(actualParams.get("Company"), is("Amazon"));
+        assertThat(actualParams.get("Title"), is("CEO"));
+        assertThat(actualParams.get("Name"), is("Larry+Pg"));
     }
 
     @Test
@@ -64,7 +78,13 @@ public class BasicHttpClientTest {
         String reqBodyAsString = "{\"state/region\":\"singapore north\",\"Company\":\"Amazon\",\"Title\":\"CEO\"}";
         RequestBuilder requestBuilder = basicHttpClient.createRequestBuilder("/api/v1/founder", "POST", header, reqBodyAsString);
         String nameValuePairString = EntityUtils.toString(requestBuilder.getEntity(), "UTF-8");
-        assertThat(nameValuePairString, is("Company=Amazon&Title=CEO&state%2Fregion=singapore+north"));
+        List<String> params = Arrays.asList(nameValuePairString.split("&"));
+        Map<String, String> actualParams = Arrays.stream(nameValuePairString.split("&"))
+            .map(entry -> entry.split("=", 2))
+            .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));  
+        assertThat(actualParams.get("Company"), is("Amazon"));
+        assertThat(actualParams.get("Title"), is("CEO"));
+        assertThat(actualParams.get("state%2Fregion"), is("singapore+north"));
     }
 
     @Test
@@ -92,7 +112,12 @@ public class BasicHttpClientTest {
         String nameValuePairString = EntityUtils.toString(requestBuilder.getEntity(), "UTF-8");
         assertThat(requestBuilder.getMethod(), is("POST"));
         //On the server side: address={city=NewYork, type=HeadOffice}
-        assertThat(nameValuePairString, is("Company=Amazon&addresses=%7Bcity%3DNewYork%2C+type%3DHeadOffice%7D"));
+        Map<String, String> actualParams = Arrays.stream(nameValuePairString.split("&"))
+                .map(entry -> entry.split("=", 2))
+                .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));
+            
+        assertThat(actualParams.get("Company"), is("Amazon"));
+        assertThat(actualParams.get("addresses"), is("%7Bcity%3DNewYork%2C+type%3DHeadOffice%7D"));
     }
 
     @Test


### PR DESCRIPTION
Fix for Issue https://github.com/authorjapps/zerocode/issues/733

# Fix Flaky Test in `BasicHttpClientTest`

## What is the purpose of this PR?

This pull request addresses several flaky test, in the `zerocode` project. The test was failing intermittently due to assumptions about the ordering of fields returned by the code under test. 

## Test Affected

- `BasicHttpClientTest.createRequestBuilder`
- `BasicHttpClientTest.createRequestBuilder_spaceInKeyValue`
- `BasicHttpClientTest.createRequestBuilder_frontSlash`
- `BasicHttpClientTest.createRequestBuilder_jsonValue` 

## Why the test fails

The flakiness was caused by relying on field ordering from a java.util.Map (see [BasicHttpClient.java#L305](https://github.com/authorjapps/zerocode/blob/master/core/src/main/java/org/jsmart/zerocode/core/httpclient/BasicHttpClient.java#L305)).

All test specified above relied on ordering returned by java.util.Map. It does not guarantee field order by default. This caused the test to fail when the field order changed, especially under NonDex shuffling, which explores non-deterministic behaviors.

## How to reproduce the test failure

Run the test with NonDex to simulate shuffling of field order:

```shell
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl core -Dtest=org.jsmart.zerocode.core.httpclient.BasicHttpClientTest
```

Before the fix, the test failed intermittently with errors similar to:

```
Expected: is "Company=Amazon&worthInBillion=999.999&age=30"
     but: was "age=30&worthInBillion=999.999&Company=Amazon"
```

## Expected results

The test should pass consistently, regardless of the order of fields in the returned response.

## Actual results

Before the fix, the test failed intermittently due to changes in the order of the returned response.

## Description of fix

1. **Relaxed Assertions**:
    - Replaced strict string comparisons with Map key-value checking. This ensures that field order does not affect the test results. 
    
```java        
        assertThat(actualParams.get("Company"), is("Amazon"));
        assertThat(actualParams.get("age"), is("30"));
        assertThat(actualParams.get("worthInBillion"), is("999.999"));    
```
    
## Validation

### Test Results

- Tests run **normally**: Passed
    
    ```shell
    mvn -pl core test -Dtest=org.jsmart.zerocode.core.httpclient.BasicHttpClientTest
    ```
    
<img width="1217" height="158" alt="image" src="https://github.com/user-attachments/assets/7c3d4dd4-8c57-4050-b0ff-aaccbb1926f4" />

    
- Tests run with **NonDex**: Passed consistently across multiple seeds
    
    ```shell
    mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl core -Dtest=org.jsmart.zerocode.core.httpclient.BasicHttpClientTest
    ```
    

## Additional Notes

- The fix ensures the test is robust to non-deterministic behaviors of java.util.Map and compatible with future updates to it or related dependencies.

Let me know if further improvements or clarifications are needed!