### PR TITLE
PR - Add FAQ for Java version and CI Workflow build

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -105,3 +105,98 @@ fails at runtime on JDK 8" issue, the fix is to switch to:
 
 The `--release` flag enforces both the language level **and** the
 available API surface in a single, safer setting.
+
+### Is `<release>8</release>` configured in this project?
+
+No. It is not currently in the POM. The mention of `<release>8</release>`
+in this document is a **recommended improvement**, not something already
+present. What the project uses today is:
+```xml
+<source>1.8</source>
+<target>1.8</target>
+```
+// TODO-- Raise a new Issue for this to get implemented. 
+
+---
+
+### What is the difference between `source`/`target` and `release`, and should we switch?
+
+Both approaches produce Java 8 bytecode, but `--release` is stricter:
+
+| Setting              | Bytecode = Java 8 | Blocks Java 9+ API usage |
+|----------------------|:-----------------:|:------------------------:|
+| `source`/`target`    | ✅                | ❌                       |
+| `release`            | ✅                | ✅                       |
+
+With `source/target=1.8`, a JDK 17 compiler can silently compile code
+that calls APIs introduced after Java 8 — the build succeeds, but the
+library will fail at runtime on a real JDK 8 environment. The `--release`
+flag closes that gap by also enforcing the available API surface.
+
+If you want to add this protection, either approach below works:
+
+As a property (simpler):
+```xml
+<properties>
+  <maven.compiler.release>8</maven.compiler.release>
+</properties>
+```
+
+Or directly in the compiler plugin:
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-compiler-plugin</artifactId>
+  <configuration>
+    <release>8</release>
+  </configuration>
+</plugin>
+```
+
+Note: `--release` requires JDK 9 or higher to compile with. Since the
+CI matrix includes JDK 8, you would need to guard this with a profile
+activated on JDK 9+ (similar to the existing `jdk-17plus` profile),
+or drop the JDK 8 build job if Java 8 as a **compiler** is no longer
+a requirement.
+
+### Does the Java 8 bytecode target apply to JDK 17+ builds too?
+
+Yes. The `jdk-17plus` profile does **not** change the compiler source or
+target. It only sets the `java.version` property and adds Surefire
+`--add-opens` flags for tests. Compilation is still governed by the
+parent POM properties on every matrix entry:
+
+| JDK in matrix | Bytecode target |
+|---------------|-----------------|
+| 8             | Java 8          |
+| 11            | Java 8          |
+| 17            | Java 8          |
+| 21            | Java 8          |
+| 23            | Java 8          |
+
+To verify in a CI log, add this to a Java 17+ matrix job and look for
+`-source 1.8 -target 1.8` in the compiler output:
+```sh
+mvn -ntp -X -DskipTests compile
+```
+
+---
+
+### If the bytecode is Java 8, does the library work for users on Java 17+?
+
+Yes — and this is by design. A library compiled to Java 8 bytecode can
+run on any JDK from 8 through 21, 23, and beyond, as long as it avoids
+APIs that were removed or restricted in newer runtimes. Keeping the
+bytecode target at Java 8 maximises compatibility for the widest
+possible audience of downstream users.
+
+This compatibility is **verified, not just assumed** — the CI matrix
+runs the full test suite on JDK 17, 21, and 23, and the `jdk-17plus`
+profile adds `--add-opens` flags to handle Java module-system
+restrictions during testing.
+
+The one area to watch: if the library (or any of its dependencies) uses
+JDK-internal APIs via reflection, Java's module system may block that
+access on JDK 17+, regardless of bytecode level. That is exactly what
+the `--add-opens` flags in the `jdk-17plus` profile are there to
+address.


### PR DESCRIPTION
This document explains how the project handles multiple JDK versions in CI and the relationship with Maven profiles.

# <Feature Title>

## Fixed Which Issue?
- [ ] Which issue or ticket was(will be) fixed by this PR? (capture the issue link here)

PR Branch
**_#ADD LINK TO THE PR BRANCH_**

## Motivation and Context

## Checklist:

* [ ] 1. New Unit tests were added
  * [ ] 1.1 Covered in existing Unit tests

* [ ] 2. Integration tests were added
  * [ ] 2.1 Covered in existing Integration tests

* [ ] 3. Test names are meaningful

* [ ] 3.1 Feature manually tested and outcome is successful

* [ ] 4. PR doesn't break any of the earlier features for end users
  * [ ] 4.1 WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [ ] 5. PR doesn't break the HTML report features directly
  * [ ] 5.1 Yes! I've manually run it locally and seen the HTML reports are generated perfectly fine
  * [ ] 5.2 Yes! I've opened the generated HTML reports from the `/target` folder and they look fine

* [ ] 6. PR doesn't break any HTML report features indirectly
  * [ ] 6.1 I have not added or amended any dependencies in this PR
  * [ ] 6.2 I have double checked, the new dependency added or removed has not affected the report generation indirectly
  * [ ] 6.3 Yes! I've seen the Sample report screenshots [here](https://github.com/authorjapps/zerocode/issues/694#issuecomment-2505958433), and HTML report of the current PR looks simillar.

* [ ] 7. Branch build passed in CI

* [ ] 8. No 'package.*' in the imports

* [ ] 9. Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [ ] 9.1 Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] 10. Http test added to `http-testing-examples` module(if applicable) ?
  * [ ] 10.1 Not applicable. The changes did not affect HTTP automation flow

* [ ] 11. Kafka test added to `kafka-testing-examples` module(if applicable) ?
  * [ ] 11.1 Not applicable. The changes did not affect Kafka automation flow
