### PR TITLE
ISSUE-268 # Support timezone-aware datetime assertions

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/field/FieldHasDateAfterValueAsserter.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/field/FieldHasDateAfterValueAsserter.java
@@ -2,13 +2,13 @@
 package org.jsmart.zerocode.core.engine.assertion.field;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import org.jsmart.zerocode.core.engine.assertion.JsonAsserter;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
 
 import static org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher.aMatchingMessage;
 import static org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher.aNotMatchingMessage;
+import static org.jsmart.zerocode.core.utils.DateTimeUtils.parseLocalDateTime;
 
 public class FieldHasDateAfterValueAsserter implements JsonAsserter {
     private final String path;
@@ -40,8 +40,7 @@ public class FieldHasDateAfterValueAsserter implements JsonAsserter {
         } else {
             LocalDateTime resultDT = null;
             try {
-                resultDT = LocalDateTime.parse((String) result,
-                        DateTimeFormatter.ISO_DATE_TIME);
+                resultDT = parseLocalDateTime((String) result);
                 areEqual = resultDT.isAfter(expected);
             } catch (DateTimeParseException ex) {
                 areEqual = false;

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/field/FieldHasDateBeforeValueAsserter.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/assertion/field/FieldHasDateBeforeValueAsserter.java
@@ -2,13 +2,13 @@
 package org.jsmart.zerocode.core.engine.assertion.field;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import org.jsmart.zerocode.core.engine.assertion.JsonAsserter;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
 
 import static org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher.aMatchingMessage;
 import static org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher.aNotMatchingMessage;
+import static org.jsmart.zerocode.core.utils.DateTimeUtils.parseLocalDateTime;
 
 public class FieldHasDateBeforeValueAsserter implements JsonAsserter {
     private final String path;
@@ -40,8 +40,7 @@ public class FieldHasDateBeforeValueAsserter implements JsonAsserter {
         } else {
             LocalDateTime resultDT = null;
             try {
-                resultDT = LocalDateTime.parse((String) result,
-                        DateTimeFormatter.ISO_DATE_TIME);
+                resultDT = parseLocalDateTime((String) result);
                 areEqual = resultDT.isBefore(expected);
             } catch (DateTimeParseException ex) {
                 areEqual = false;

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImpl.java
@@ -31,8 +31,6 @@ import org.jsmart.zerocode.core.engine.assertion.field.FieldMatchesRegexPatternA
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -71,6 +69,7 @@ import static org.jsmart.zerocode.core.utils.PropertiesProviderUtils.loadAbsolut
 import static org.jsmart.zerocode.core.utils.SmartUtils.checkDigNeeded;
 import static org.jsmart.zerocode.core.utils.SmartUtils.getJsonFilePhToken;
 import static org.jsmart.zerocode.core.utils.SmartUtils.isValidAbsolutePath;
+import static org.jsmart.zerocode.core.utils.DateTimeUtils.parseLocalDateTime;
 import static org.jsmart.zerocode.core.utils.TokenUtils.getMasksRemoved;
 import static org.jsmart.zerocode.core.utils.TokenUtils.getMasksReplaced;
 import static org.jsmart.zerocode.core.utils.TokenUtils.getTestCaseTokens;
@@ -435,10 +434,6 @@ public class ZeroCodeAssertionsProcessorImpl implements ZeroCodeAssertionsProces
 
     private boolean isPropertyKey(String runTimeToken) {
         return propertyKeys.contains(runTimeToken);
-    }
-
-    private LocalDateTime parseLocalDateTime(String value) {
-        return LocalDateTime.parse(value, DateTimeFormatter.ISO_DATE_TIME);
     }
 
     boolean isPathValueJson(Object jsonPathValue) {

--- a/core/src/main/java/org/jsmart/zerocode/core/utils/DateTimeUtils.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/utils/DateTimeUtils.java
@@ -1,0 +1,29 @@
+package org.jsmart.zerocode.core.utils;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class DateTimeUtils {
+
+    public static LocalDateTime parseLocalDateTime(String value) {
+        try {
+            return ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME)
+                    .withZoneSameInstant(ZoneId.systemDefault())
+                    .toLocalDateTime();
+        } catch (DateTimeParseException ignored) {
+        }
+
+        try {
+            return OffsetDateTime.parse(value, DateTimeFormatter.ISO_DATE_TIME)
+                    .atZoneSameInstant(ZoneId.systemDefault())
+                    .toLocalDateTime();
+        } catch (DateTimeParseException ignored) {
+        }
+
+        return LocalDateTime.parse(value, DateTimeFormatter.ISO_DATE_TIME);
+    }
+}

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImplTest.java
@@ -30,12 +30,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static com.jayway.jsonpath.JsonPath.read;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.jsmart.zerocode.core.utils.HelperJsonUtils.readJsonPath;
+import static org.jsmart.zerocode.core.utils.DateTimeUtils.parseLocalDateTime;
 import static org.jsmart.zerocode.core.utils.SmartUtils.checkDigNeeded;
 import static org.jsmart.zerocode.core.utils.SmartUtils.readJsonAsString;
 import static org.jsmart.zerocode.core.utils.TokenUtils.getTestCaseTokens;
@@ -978,6 +980,46 @@ public class ZeroCodeAssertionsProcessorImplTest {
     }
 
     @Test
+    public void testDateAfterBefore_withTimeZoneOffsetsAndHttpDate() throws Exception {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        try {
+            String resolvedAssertions =
+                    "{\n"
+                            + "    \"status\": 200,\n"
+                            + "    \"body\": {\n"
+                            + "        \"projectDetails\": {\n"
+                            + "            \"startDateTime\": \"$LOCAL.DATETIME.BEFORE:2019-06-15T10:00:00.000Z\",\n"
+                            + "            \"endDateTime\": \"$LOCAL.DATETIME.AFTER:2019-06-15T10:00:00.000Z\",\n"
+                            + "            \"lastModified\": \"$LOCAL.DATETIME.BEFORE:Sat, 06 Jul 2019 17:07:15 GMT\"\n"
+                            + "        }\n"
+                            + "    }\n"
+                            + "}";
+
+            List<JsonAsserter> asserters = jsonPreProcessor.createJsonAsserters(resolvedAssertions);
+            assertThat(asserters.size(), is(4));
+
+            String mockTestResponse =
+                    "{\n"
+                            + "    \"status\": 200,\n"
+                            + "    \"body\": {\n"
+                            + "        \"projectDetails\": {\n"
+                            + "            \"startDateTime\": \"2019-06-15T11:30:00.000+02:00\",\n"
+                            + "            \"endDateTime\": \"2019-06-15T12:30:00.000+02:00\",\n"
+                            + "            \"lastModified\": \"Sat, 06 Jul 2019 16:07:15 GMT\"\n"
+                            + "        }\n"
+                            + "    }\n"
+                            + "}";
+
+            List<FieldAssertionMatcher> failedReports =
+                    jsonPreProcessor.assertAllAndReturnFailed(asserters, mockTestResponse);
+            assertThat(failedReports.size(), is(0));
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    @Test
     public void testDateAfterBefore_fail_both() throws Exception {
         ScenarioSpec scenarioSpec =
                 smartUtils.scenarioFileToJava(
@@ -1018,12 +1060,12 @@ public class ZeroCodeAssertionsProcessorImplTest {
                 failedReports.get(0).toString(),
                 is(
                         "Assertion jsonPath '$.body.projectDetails.startDateTime' with actual value '2017-04-14T11:49:56.000Z' "
-                                + "did not match the expected value 'Date Before:2016-09-14T09:49:34'"));
+                                + "did not match the expected value 'Date Before:" + parseLocalDateTime("2016-09-14T09:49:34.000Z") + "'"));
         assertThat(
                 failedReports.get(1).toString(),
                 is(
                         "Assertion jsonPath '$.body.projectDetails.endDateTime' with actual value '2018-11-12T09:39:34.000Z' "
-                                + "did not match the expected value 'Date After:2019-09-14T09:49:34'"));
+                                + "did not match the expected value 'Date After:" + parseLocalDateTime("2019-09-14T09:49:34.000Z") + "'"));
     }
 
     @Test
@@ -1063,7 +1105,7 @@ public class ZeroCodeAssertionsProcessorImplTest {
                 failedReports.get(0).toString(),
                 is(
                         "Assertion jsonPath '$.body.projectDetails.startDateTime' with actual value '2015-09-14T09:49:34.000Z' "
-                                + "did not match the expected value 'Date After:2015-09-14T09:49:34'"));
+                                + "did not match the expected value 'Date After:" + parseLocalDateTime("2015-09-14T09:49:34.000Z") + "'"));
     }
 
     @Test
@@ -1103,7 +1145,7 @@ public class ZeroCodeAssertionsProcessorImplTest {
                 failedReports.get(0).toString(),
                 is(
                         "Assertion jsonPath '$.body.projectDetails.startDateTime' with actual value '2015-09-14T09:49:34.000Z' "
-                                + "did not match the expected value 'Date Before:2015-09-14T09:49:34'"));
+                                + "did not match the expected value 'Date Before:" + parseLocalDateTime("2015-09-14T09:49:34.000Z") + "'"));
     }
 
     @Test


### PR DESCRIPTION
# Support timezone-aware datetime assertions

## Fixed Which Issue?
- [x] Fixes https://github.com/authorjapps/zerocode/issues/268
- [x] Fixes https://github.com/authorjapps/zerocode/issues/776

PR Branch
**_https://github.com/officialasishkumar/zerocode/tree/issue-268-date-timezone_**

## Motivation and Context
`$LOCAL.DATETIME.AFTER` and `$LOCAL.DATETIME.BEFORE` parsed ISO datetimes into `LocalDateTime`, which ignored offset semantics for values such as `Z` or `+02:00`. That meant comparisons used the wall-clock value instead of comparing equivalent instants.

This change adds a shared datetime parser for assertion expected values and actual response values. It preserves plain ISO local datetime support, honors ISO offsets and `Z`, and adds RFC-1123 HTTP-date parsing for values such as `Last-Modified`.

Validation run locally:

```sh
mvn -pl core -Dtest=ZeroCodeAssertionsProcessorImplTest test -ntp
```

## Checklist:

* [x] 1. New Unit tests were added
  * [ ] 1.1 Covered in existing Unit tests

* [ ] 2. Integration tests were added
  * [ ] 2.1 Covered in existing Integration tests

* [x] 3. Test names are meaningful

* [x] 3.1 Feature manually tested and outcome is successful

* [x] 4. PR doesn't break any of the earlier features for end users
  * [ ] 4.1 WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [x] 5. PR doesn't break the HTML report features directly
  * [ ] 5.1 Yes! I've manually run it locally and seen the HTML reports are generated perfectly fine
  * [ ] 5.2 Yes! I've opened the generated HTML reports from the `/target` folder and they look fine

* [x] 6. PR doesn't break any HTML report features indirectly
  * [x] 6.1 I have not added or amended any dependencies in this PR
  * [ ] 6.2 I have double checked, the new dependency added or removed has not affected the report generation indirectly
  * [ ] 6.3 Yes! I've seen the Sample report screenshots [here](https://github.com/authorjapps/zerocode/issues/694#issuecomment-2505958433), and HTML report of the current PR looks simillar.

* [ ] 7. Branch build passed in CI

* [x] 8. No 'package.*' in the imports

* [x] 9. Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [x] 9.1 Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] 10. Http test added to `http-testing-examples` module(if applicable) ?
  * [x] 10.1 Not applicable. The changes did not affect HTTP automation flow

* [ ] 11. Kafka test added to `kafka-testing-examples` module(if applicable) ?
  * [x] 11.1 Not applicable. The changes did not affect Kafka automation flow
