### PR TITLE
ISSUE-466 # Handle unknown-length empty HTTP responses

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/httpclient/BasicHttpClient.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/httpclient/BasicHttpClient.java
@@ -1,5 +1,6 @@
 package org.jsmart.zerocode.core.httpclient;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -186,12 +187,28 @@ public class BasicHttpClient {
      */
     public Response createCharsetResponse(CloseableHttpResponse httpResponse) throws IOException {
         HttpEntity entity = httpResponse.getEntity();
-        Charset charset = ContentType.getOrDefault(httpResponse.getEntity()).getCharset();
+        Charset charset = entity == null ? null : ContentType.getOrDefault(entity).getCharset();
         charset = (charset == null) ? Charset.defaultCharset() : charset;
         return Response
                 .status(httpResponse.getStatusLine().getStatusCode())
-                .entity(entity != null ? IOUtils.toString(entity.getContent(), charset) : null)
+                .entity(readResponseEntity(entity, charset))
                 .build();
+    }
+
+    private String readResponseEntity(HttpEntity entity, Charset charset) throws IOException {
+        if (entity == null || entity.getContentLength() == 0) {
+            return null;
+        }
+
+        try {
+            return IOUtils.toString(entity.getContent(), charset);
+        } catch (EOFException ex) {
+            if (entity.getContentLength() < 0) {
+                LOGGER.warn("Received EOF while reading response body with unknown content length. Treating body as empty.");
+                return null;
+            }
+            throw ex;
+        }
     }
 
     /**

--- a/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/httpclient/BasicHttpClientTest.java
@@ -2,6 +2,7 @@ package org.jsmart.zerocode.core.httpclient;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -9,6 +10,9 @@ import java.util.Map;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.RequestBuilder;
@@ -28,6 +32,8 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BasicHttpClientTest {
     private BasicHttpClient basicHttpClient;
@@ -215,5 +221,24 @@ public class BasicHttpClientTest {
         BasicHttpClient basicHttpClient = new BasicHttpClient();
         final String responseBodyActual = (String) basicHttpClient.handleResponse(closeableHttpResponse).getEntity();
         assertThat(responseBodyActual, CoreMatchers.is(response));
+    }
+
+    @Test
+    public void willHandleUnknownLengthEmptyResponse() throws Exception {
+        CloseableHttpResponse closeableHttpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        HttpEntity entity = mock(HttpEntity.class);
+
+        when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
+        when(closeableHttpResponse.getEntity()).thenReturn(entity);
+        when(closeableHttpResponse.getAllHeaders()).thenReturn(new Header[0]);
+        when(statusLine.getStatusCode()).thenReturn(401);
+        when(entity.getContentLength()).thenReturn(-1L);
+        when(entity.getContent()).thenThrow(new EOFException());
+
+        javax.ws.rs.core.Response handledResponse = basicHttpClient.handleResponse(closeableHttpResponse);
+
+        assertThat(handledResponse.getStatus(), is(401));
+        assertThat(handledResponse.getEntity(), is((Object) null));
     }
 }


### PR DESCRIPTION
# Handle unknown-length empty HTTP responses

## Fixed Which Issue?
- [x] Fixes https://github.com/authorjapps/zerocode/issues/466

PR Branch
**_https://github.com/officialasishkumar/zerocode/tree/issue-466-empty-http-response_**

## Motivation and Context
Some HTTP responses can legally return a status with no body and no `Content-Length`. When Apache HttpClient exposes such a response as an unknown-length entity and reading the stream raises `EOFException`, Zerocode currently fails the step before assertions can validate the status.

This change treats EOF from an unknown-length response entity as an empty response body while still preserving valid unknown-length bodies when they can be read normally.

Validation run locally:

```sh
mvn -pl core -Dtest=BasicHttpClientTest test -ntp
```

## Checklist:

* [x] 1. New Unit tests were added
  * [ ] 1.1 Covered in existing Unit tests

* [ ] 2. Integration tests were added
  * [ ] 2.1 Covered in existing Integration tests

* [x] 3. Test names are meaningful

* [x] 3.1 Feature manually tested and outcome is successful

* [x] 4. PR doesn't break any of the earlier features for end users
  * [ ] 4.1 WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [x] 5. PR doesn't break the HTML report features directly
  * [ ] 5.1 Yes! I've manually run it locally and seen the HTML reports are generated perfectly fine
  * [ ] 5.2 Yes! I've opened the generated HTML reports from the `/target` folder and they look fine

* [x] 6. PR doesn't break any HTML report features indirectly
  * [x] 6.1 I have not added or amended any dependencies in this PR
  * [ ] 6.2 I have double checked, the new dependency added or removed has not affected the report generation indirectly
  * [ ] 6.3 Yes! I've seen the Sample report screenshots [here](https://github.com/authorjapps/zerocode/issues/694#issuecomment-2505958433), and HTML report of the current PR looks simillar.

* [ ] 7. Branch build passed in CI

* [x] 8. No 'package.*' in the imports

* [x] 9. Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [x] 9.1 Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] 10. Http test added to `http-testing-examples` module(if applicable) ?
  * [x] 10.1 Not applicable. The changes did not affect HTTP automation flow

* [ ] 11. Kafka test added to `kafka-testing-examples` module(if applicable) ?
  * [x] 11.1 Not applicable. The changes did not affect Kafka automation flow
