### PR TITLE
Resolve property placeholders in target-env files

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/di/main/ApplicationMainModule.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/main/ApplicationMainModule.java
@@ -2,8 +2,11 @@ package org.jsmart.zerocode.core.di.main;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
+import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jsmart.zerocode.core.di.module.CsvParserModule;
 import org.jsmart.zerocode.core.di.module.GsonModule;
 import org.jsmart.zerocode.core.di.module.HttpClientModule;
@@ -30,12 +33,15 @@ import org.jsmart.zerocode.core.report.ZeroCodeReportGeneratorImpl;
 import org.jsmart.zerocode.core.runner.ZeroCodeMultiStepsScenarioRunner;
 import org.jsmart.zerocode.core.runner.ZeroCodeMultiStepsScenarioRunnerImpl;
 
+import static org.jsmart.zerocode.core.utils.EnvUtils.getEnvValueString;
 import static org.jsmart.zerocode.core.utils.PropertiesProviderUtils.checkAndLoadOldProperties;
 import static org.jsmart.zerocode.core.utils.PropertiesProviderUtils.loadAbsoluteProperties;
 import static org.jsmart.zerocode.core.utils.SmartUtils.isValidAbsolutePath;
 
 public class ApplicationMainModule extends AbstractModule {
     private static final Logger LOGGER = Logger.getLogger(ApplicationMainModule.class.getName());
+
+    private static final Pattern ENV_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
 
     private final String serverEnv;
 
@@ -79,7 +85,7 @@ public class ApplicationMainModule extends AbstractModule {
         final Properties properties = new Properties();
 
         if(isValidAbsolutePath(host)){
-            return loadAbsoluteProperties(host, properties);
+            return resolveEnvPlaceholders(loadAbsoluteProperties(host, properties));
         }
 
         try {
@@ -96,7 +102,54 @@ public class ApplicationMainModule extends AbstractModule {
             throw new RuntimeException("could not read the target-env properties file --" + host + "-- from the classpath.");
         }
 
+        return resolveEnvPlaceholders(properties);
+    }
+
+    /**
+     * Resolves any {@code ${name}} placeholders found in the loaded property values against
+     * system properties and OS environment variables (in that order, via
+     * {@link org.jsmart.zerocode.core.utils.EnvUtils#getEnvValueString(String)}).
+     * <p>
+     * This lets a target-env properties file reference values supplied on the command line, e.g.
+     * <pre>
+     *     db.username=${db.username}
+     * </pre>
+     * run with {@code -Ddb.username=alice} so the injected value becomes {@code alice}.
+     * <p>
+     * A placeholder whose name resolves to no system property or env var is left untouched, so
+     * files that legitimately contain {@code ${...}} for downstream tooling are not corrupted.
+     * Values without any placeholder are returned unchanged.
+     */
+    public Properties resolveEnvPlaceholders(Properties properties) {
+        if (properties == null) {
+            return null;
+        }
+
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof String) {
+                properties.setProperty((String) entry.getKey(), resolvePlaceholders((String) value));
+            }
+        }
+
         return properties;
+    }
+
+    private static String resolvePlaceholders(String value) {
+        Matcher matcher = ENV_PLACEHOLDER_PATTERN.matcher(value);
+        StringBuffer resolved = new StringBuffer();
+
+        while (matcher.find()) {
+            String placeholderName = matcher.group(1);
+            String replacement = getEnvValueString(placeholderName);
+
+            // Leave the placeholder literally in place when it cannot be resolved (backward compatible).
+            String token = replacement != null ? replacement : matcher.group(0);
+            matcher.appendReplacement(resolved, Matcher.quoteReplacement(token));
+        }
+        matcher.appendTail(resolved);
+
+        return resolved.toString();
     }
 
 }

--- a/core/src/test/java/org/jsmart/zerocode/core/di/ApplicationMainModuleTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/di/ApplicationMainModuleTest.java
@@ -3,9 +3,11 @@ package org.jsmart.zerocode.core.di;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import java.util.Properties;
 import org.jsmart.zerocode.core.di.main.ApplicationMainModule;
 import org.jsmart.zerocode.core.guice.ZeroCodeGuiceTestRule;
 import org.jsmart.zerocode.core.utils.SmartUtils;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -47,6 +49,42 @@ public class ApplicationMainModuleTest {
     @Test
     public void willInject_host() throws Exception {
         assertThat(host, is("http://localhost-test"));
+    }
+
+    @After
+    public void clearTestSystemProperties() {
+        System.clearProperty("zc.test.host");
+    }
+
+    @Test
+    public void willResolveSystemPropertyPlaceholder() throws Exception {
+        System.setProperty("zc.test.host", "http://resolved-host");
+
+        ApplicationMainModule module = new ApplicationMainModule("config_hosts_test.properties");
+        Properties properties = module.getProperties("config_hosts_test.properties");
+
+        assertThat(properties.getProperty("placeholder.resolved.host"), is("http://resolved-host"));
+    }
+
+    @Test
+    public void willKeepUnresolvedPlaceholderLiteral() throws Exception {
+        ApplicationMainModule module = new ApplicationMainModule("config_hosts_test.properties");
+        Properties properties = module.getProperties("config_hosts_test.properties");
+
+        // No matching system property / env var -> placeholder is preserved verbatim (backward compatible).
+        assertThat(properties.getProperty("placeholder.unresolved.host"), is("${zc.test.absent.host}"));
+    }
+
+    @Test
+    public void willReturnPlainPropertyUnchanged() throws Exception {
+        ApplicationMainModule module = new ApplicationMainModule("config_hosts_test.properties");
+
+        Properties input = new Properties();
+        input.setProperty("plain.key", "plain-value-without-placeholder");
+
+        Properties resolved = module.resolveEnvPlaceholders(input);
+
+        assertThat(resolved.getProperty("plain.key"), is("plain-value-without-placeholder"));
     }
 
 }

--- a/core/src/test/resources/config_hosts_test.properties
+++ b/core/src/test/resources/config_hosts_test.properties
@@ -4,3 +4,7 @@ web.application.endpoint.port=8820
 
 # Google Map Service Context
 web.application.endpoint.context=/google-map-services
+
+# Placeholders resolved against system properties / OS env vars at load time
+placeholder.resolved.host=${zc.test.host}
+placeholder.unresolved.host=${zc.test.absent.host}


### PR DESCRIPTION
# <Feature Title>

Resolve property placeholders in target-env files

## Fixed Which Issue?
- [x] Fixes #526 -- https://github.com/authorjapps/zerocode/issues/526

PR Branch
**_mvanhorn:feat/526-env-placeholder-resolution_**

## Motivation and Context

When a target-env properties file (loaded via `@TargetEnv` /
`ApplicationMainModule`) contains a value referencing a `${name}` placeholder,
e.g.

```
db.username=${db.username}
```

Zerocode loaded the file verbatim and injected the literal `${db.username}`
string. Users expect to parameterize their target-env files from the command
line (`-Ddb.username=alice`) so secrets and per-environment values don't have to
be committed.

This PR post-processes the loaded `Properties` so that any value containing one
or more `${name}` tokens has each token replaced by its resolved value.
Resolution reuses the existing `EnvUtils.getEnvValueString(name)` helper, which
checks `System.getProperty(name)` first and falls back to `System.getenv(name)`
-- so no new resolution semantics are introduced and behavior matches how the
rest of the framework reads env values. Both the classpath-load and absolute-path
load paths go through the same helper.

The change is additive and backward compatible: a placeholder that resolves to
nothing is left untouched, and a value with no placeholder is returned unchanged,
so existing property files are not affected.

## Checklist:

* [x] 1. New Unit tests were added
  * [x] 1.1 Covered in existing Unit tests

* [ ] 2. Integration tests were added
  * [x] 2.1 Covered in existing Integration tests

* [x] 3. Test names are meaningful

* [x] 3.1 Feature manually tested and outcome is successful

* [x] 4. PR doesn't break any of the earlier features for end users

* [x] 5. PR doesn't break the HTML report features directly

* [x] 6. PR doesn't break any HTML report features indirectly
  * [x] 6.1 I have not added or amended any dependencies in this PR

* [x] 7. Branch build passed in CI

* [x] 8. No 'package.*' in the imports

* [ ] 9. Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [x] 9.1 Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced

* [ ] 10. Http test added to `http-testing-examples` module(if applicable) ?
  * [x] 10.1 Not applicable. The changes did not affect HTTP automation flow

* [ ] 11. Kafka test added to `kafka-testing-examples` module(if applicable) ?
  * [x] 11.1 Not applicable. The changes did not affect Kafka automation flow
