### PR TITLE
Issue-782 # Support {{...}} double curly brace based as alternate placeholder delimiter alongside ${...}

### DIFF
--- a/core/src/main/java/org/jsmart/zerocode/core/di/main/ApplicationMainModule.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/di/main/ApplicationMainModule.java
@@ -41,7 +41,7 @@ import static org.jsmart.zerocode.core.utils.SmartUtils.isValidAbsolutePath;
 public class ApplicationMainModule extends AbstractModule {
     private static final Logger LOGGER = Logger.getLogger(ApplicationMainModule.class.getName());
 
-    private static final Pattern ENV_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
+    private static final Pattern ENV_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}|\\{\\{([^}]+)\\}\\}");
 
     private final String serverEnv;
 
@@ -106,18 +106,18 @@ public class ApplicationMainModule extends AbstractModule {
     }
 
     /**
-     * Resolves any {@code ${name}} placeholders found in the loaded property values against
+     * Resolves any {@code ${name}} or {@code {{name}}} placeholders found in the loaded property values against
      * system properties and OS environment variables (in that order, via
      * {@link org.jsmart.zerocode.core.utils.EnvUtils#getEnvValueString(String)}).
      * <p>
      * This lets a target-env properties file reference values supplied on the command line, e.g.
      * <pre>
-     *     db.username=${db.username}
+     *     db.username={{db.username}}
      * </pre>
      * run with {@code -Ddb.username=alice} so the injected value becomes {@code alice}.
      * <p>
      * A placeholder whose name resolves to no system property or env var is left untouched, so
-     * files that legitimately contain {@code ${...}} for downstream tooling are not corrupted.
+     * files that legitimately contain either placeholder style for downstream tooling are not corrupted.
      * Values without any placeholder are returned unchanged.
      */
     public Properties resolveEnvPlaceholders(Properties properties) {
@@ -140,7 +140,7 @@ public class ApplicationMainModule extends AbstractModule {
         StringBuffer resolved = new StringBuffer();
 
         while (matcher.find()) {
-            String placeholderName = matcher.group(1);
+            String placeholderName = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
             String replacement = getEnvValueString(placeholderName);
 
             // Leave the placeholder literally in place when it cannot be resolved (backward compatible).

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImpl.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.jayway.jsonpath.JsonPath;
-import org.apache.commons.text.StringSubstitutor;
 import org.jsmart.zerocode.core.domain.Step;
 import org.jsmart.zerocode.core.engine.assertion.FieldAssertionMatcher;
 import org.jsmart.zerocode.core.engine.assertion.JsonAsserter;
@@ -75,6 +74,7 @@ import static org.jsmart.zerocode.core.utils.TokenUtils.getMasksRemoved;
 import static org.jsmart.zerocode.core.utils.TokenUtils.getMasksReplaced;
 import static org.jsmart.zerocode.core.utils.TokenUtils.getTestCaseTokens;
 import static org.jsmart.zerocode.core.utils.TokenUtils.populateParamMap;
+import static org.jsmart.zerocode.core.utils.TokenUtils.replaceTokens;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class ZeroCodeAssertionsProcessorImpl implements ZeroCodeAssertionsProcessor {
@@ -116,9 +116,7 @@ public class ZeroCodeAssertionsProcessorImpl implements ZeroCodeAssertionsProces
 
         });
 
-        StringSubstitutor sub = new StringSubstitutor(paramMap);
-
-        return sub.replace(requestJsonOrAnyString);
+        return replaceTokens(requestJsonOrAnyString, paramMap);
     }
 
     @Override
@@ -165,9 +163,7 @@ public class ZeroCodeAssertionsProcessorImpl implements ZeroCodeAssertionsProces
             }
         });
 
-        StringSubstitutor sub = new StringSubstitutor(paramMap);
-
-        return sub.replace(jsonString);
+        return replaceTokens(jsonString, paramMap);
     }
 
     @Override

--- a/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImpl.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImpl.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.text.StringSubstitutor;
 import org.jsmart.zerocode.core.di.provider.CsvParserProvider;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
 import org.jsmart.zerocode.core.utils.TokenUtils;
@@ -162,12 +161,11 @@ public class ZeroCodeParameterizedProcessorImpl implements ZeroCodeParameterized
     }
 
     private String replaceWithValues(String stepJson, Map<String, Object> valuesMap) {
-        StringSubstitutor sub = new StringSubstitutor(valuesMap);
-        return sub.replace(stepJson);
+        return TokenUtils.replaceTokens(stepJson, valuesMap);
     }
 
     private void ensureAllParamsResolved(String resultantStepJson, String[] availableHeaders) {
-        Pattern pattern = Pattern.compile("\\$\\{PARAM\\.([^}]+)\\}");
+        Pattern pattern = Pattern.compile("\\$\\{PARAM\\.([^}]+)\\}|\\{\\{PARAM\\.([^}]+)\\}\\}");
         Matcher matcher = pattern.matcher(resultantStepJson);
         
         if (matcher.find()) {
@@ -177,7 +175,8 @@ public class ZeroCodeParameterizedProcessorImpl implements ZeroCodeParameterized
             } else {
                 msg = "Available headers are: [" + String.join(", ", availableHeaders) + "].";
             }
-            throw new RuntimeException("Invalid CSV header referenced in scenario. The column '" + matcher.group(1) + "' does not exist. " + msg);
+            String missingHeader = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+            throw new RuntimeException("Invalid CSV header referenced in scenario. The column '" + missingHeader + "' does not exist. " + msg);
             
         }
     }

--- a/core/src/main/java/org/jsmart/zerocode/core/utils/SmartUtils.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/utils/SmartUtils.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.text.StringSubstitutor;
 import org.jsmart.zerocode.core.di.provider.ObjectMapperProvider;
 import org.jsmart.zerocode.core.domain.ScenarioSpec;
 import org.jsmart.zerocode.core.domain.Step;
@@ -321,8 +320,7 @@ public class SmartUtils {
     }
 
     public static String resolveToken(String stringWithToken, Map<String, String> paramMap) {
-        StringSubstitutor sub = new StringSubstitutor(paramMap);
-        return sub.replace(stringWithToken);
+        return TokenUtils.replaceTokens(stringWithToken, paramMap);
     }
 
     public static String getEnvPropertyValue(String envPropertyKey) {

--- a/core/src/main/java/org/jsmart/zerocode/core/utils/TokenUtils.java
+++ b/core/src/main/java/org/jsmart/zerocode/core/utils/TokenUtils.java
@@ -23,6 +23,9 @@ import static org.jsmart.zerocode.core.engine.tokens.ZeroCodeValueTokens.*;
 
 public class TokenUtils {
 
+    private static final Pattern TEST_CASE_TOKEN_PATTERN = Pattern.compile("\\$\\{(.+?)\\}|\\{\\{(.+?)\\}\\}");
+    private static final Pattern MASKED_TOKEN_PATTERN = Pattern.compile("\\$\\{MASKED:([^}]*)\\}|\\{\\{MASKED:([^}]*)\\}\\}");
+
     public static String resolveKnownTokens(String requestJsonOrAnyString) {
         Map<String, Object> paramMap = new HashMap<>();
 
@@ -31,9 +34,7 @@ public class TokenUtils {
             populateParamMap(paramMap, runTimeToken);
         });
 
-        StringSubstitutor sub = new StringSubstitutor(paramMap);
-
-        return sub.replace(requestJsonOrAnyString);
+        return replaceTokens(requestJsonOrAnyString, paramMap);
     }
 
     public static void populateParamMap(Map<String, Object> paramaMap, String runTimeToken) {
@@ -141,21 +142,19 @@ public class TokenUtils {
      */
     public static List<String> getTestCaseTokens(String aString) {
 
-        Pattern pattern = Pattern.compile("\\$\\{(.+?)\\}");
-        Matcher matcher = pattern.matcher(aString);
+        Matcher matcher = TEST_CASE_TOKEN_PATTERN.matcher(aString);
 
         List<String> keyTokens = new ArrayList<>();
 
         while (matcher.find()) {
-            keyTokens.add(matcher.group(1));
+            keyTokens.add(matcher.group(1) != null ? matcher.group(1) : matcher.group(2));
         }
 
         return keyTokens;
     }
 
     public static String getMasksReplaced(String aString) {
-        String regex = "\\$\\{MASKED:([^\\}]*)\\}";
-        Matcher maskMatcher = Pattern.compile(regex).matcher(aString);
+        Matcher maskMatcher = MASKED_TOKEN_PATTERN.matcher(aString);
         while(maskMatcher.find()) {
             String foundMatch = maskMatcher.group(0);
             aString = aString.replace(foundMatch, MASKED_STR);
@@ -165,15 +164,35 @@ public class TokenUtils {
     }
 
     public static String getMasksRemoved(String aString) {
-        String regex = "\\$\\{MASKED:([^\\}]*)\\}";
-        Matcher maskMatcher = Pattern.compile(regex).matcher(aString);
+        Matcher maskMatcher = MASKED_TOKEN_PATTERN.matcher(aString);
         while(maskMatcher.find()) {
             String foundFullMatch = maskMatcher.group(0);
-            String innerContent = maskMatcher.group(1);
+            String innerContent = maskMatcher.group(1) != null ? maskMatcher.group(1) : maskMatcher.group(2);
             aString = aString.replace(foundFullMatch, innerContent);
         }
 
         return aString;
+    }
+
+    /**
+     * Replaces values in both supported placeholder styles. Existing ${...} replacement is
+     * deliberately performed first to preserve its long-standing StringSubstitutor behaviour.
+     * A double-brace token is replaced only when a corresponding non-null map value exists;
+     * unrelated template expressions therefore remain literal.
+     */
+    public static String replaceTokens(String value, Map<String, ?> paramMap) {
+        String resolved = new StringSubstitutor(paramMap).replace(value);
+        Matcher matcher = Pattern.compile("\\{\\{(.+?)\\}\\}").matcher(resolved);
+        StringBuffer result = new StringBuffer();
+
+        while (matcher.find()) {
+            Object replacement = paramMap.get(matcher.group(1));
+            String token = replacement != null ? replacement.toString() : matcher.group(0);
+            matcher.appendReplacement(result, Matcher.quoteReplacement(token));
+        }
+        matcher.appendTail(result);
+
+        return result.toString();
     }
 
     public static String createRandomAlphaString(int length) {

--- a/core/src/test/java/org/jsmart/zerocode/core/di/ApplicationMainModuleTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/di/ApplicationMainModuleTest.java
@@ -64,6 +64,7 @@ public class ApplicationMainModuleTest {
         Properties properties = module.getProperties("config_hosts_test.properties");
 
         assertThat(properties.getProperty("placeholder.resolved.host"), is("http://resolved-host"));
+        assertThat(properties.getProperty("placeholder.resolved.double.host"), is("http://resolved-host"));
     }
 
     @Test
@@ -73,6 +74,7 @@ public class ApplicationMainModuleTest {
 
         // No matching system property / env var -> placeholder is preserved verbatim (backward compatible).
         assertThat(properties.getProperty("placeholder.unresolved.host"), is("${zc.test.absent.host}"));
+        assertThat(properties.getProperty("placeholder.unresolved.double.host"), is("{{zc.test.absent.host}}"));
     }
 
     @Test

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeAssertionsProcessorImplTest.java
@@ -75,6 +75,22 @@ public class ZeroCodeAssertionsProcessorImplTest {
         placeHolders = getTestCaseTokens(aString);
         assertThat(placeHolders.size(), is(1));
         assertThat(placeHolders.get(0), is("$.step_name"));
+
+        aString = "Hello_{{web.application.endpoint.host}}";
+        placeHolders = getTestCaseTokens(aString);
+        assertThat(placeHolders.size(), is(1));
+        assertThat(placeHolders.get(0), is("web.application.endpoint.host"));
+    }
+
+    @Test
+    public void willResolveDoubleBracePropertiesAndMixedJsonPaths() throws Exception {
+        String scenarioState = "{\"previous\":{\"response\":{\"body\":{\"name\":\"Shower\"}}}}";
+        String resolved = jsonPreProcessor.resolveStringJson(
+                "{\"url\":\"{{web.application.endpoint.host}}/${web.application.endpoint.port}\",\"name\":\"{{$.previous.response.body.name}}\"}",
+                scenarioState);
+
+        assertThat(readJsonPath(resolved, "$.url", String.class), is("http://localhost-test/8820"));
+        assertThat(readJsonPath(resolved, "$.name", String.class), is("Shower"));
     }
 
     @Test

--- a/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImplTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/engine/preprocessor/ZeroCodeParameterizedProcessorImplTest.java
@@ -122,8 +122,20 @@ public class ZeroCodeParameterizedProcessorImplTest {
         assertThat(scenarioSpecResolved.getSteps().get(0).getRequest().get("body").get("name").asText(), is("octocat"));
     }
 
+    @Test
+    public void testProcessParameterized_csv_with_double_brace_headers() throws Exception {
+        String json = "{\"steps\":[{\"name\":\"get_user\",\"url\":\"/users/{{PARAM.id}}/{{0}}\",\"request\":{\"body\":{\"name\":\"{{PARAM.name}}\"}},\"assertions\":{\"status\":\"{{PARAM.status}}\"}}],\"parameterized\":{\"withHeaders\":true,\"csvSource\":[\"id,name,status\",\"1,octocat,200\"]}}";
+        ScenarioSpec scenarioSpec = mapper.readValue(json, ScenarioSpec.class);
+
+        ScenarioSpec resolved = parameterizedProcessor.resolveParameterized(scenarioSpec, 0);
+
+        assertThat(resolved.getSteps().get(0).getUrl(), is("/users/1/1"));
+        assertThat(resolved.getSteps().get(0).getRequest().get("body").get("name").asText(), is("octocat"));
+        assertThat(resolved.getSteps().get(0).getAssertions().get("status").asInt(), is(200));
+    }
+
    @Test
-    public void testProcessParameterized_csv_with_invalid_header_throws_exception() throws Exception {
+   public void testProcessParameterized_csv_with_invalid_header_throws_exception() throws Exception {
         String jsonDocumentAsString = smartUtils
                 .getJsonDocumentAsString("unit_test_files/engine_unit_test_jsons/11.4_scenario_parameterized_csv_with_invalid_header.json");
         ScenarioSpec scenarioSpec = mapper.readValue(jsonDocumentAsString, ScenarioSpec.class);
@@ -140,6 +152,20 @@ public class ZeroCodeParameterizedProcessorImplTest {
 
             org.junit.Assert.assertTrue("Message should contain the available headers", 
                     ex.getMessage().contains("Available headers are: [id, name]."));
+        }
+    }
+
+    @Test
+    public void testProcessParameterized_csv_with_invalid_double_brace_header_throws_exception() throws Exception {
+        String json = "{\"steps\":[{\"name\":\"get_user\",\"url\":\"/users/{{PARAM.typoHere}}\"}],\"parameterized\":{\"withHeaders\":true,\"csvSource\":[\"id,name\",\"1,octocat\"]}}";
+        ScenarioSpec scenarioSpec = mapper.readValue(json, ScenarioSpec.class);
+
+        try {
+            parameterizedProcessor.resolveParameterized(scenarioSpec, 0);
+            org.junit.Assert.fail("Expected RuntimeException was not thrown for missing CSV header");
+        } catch (RuntimeException ex) {
+            org.junit.Assert.assertTrue(ex.getMessage().contains("The column 'typoHere' does not exist"));
+            org.junit.Assert.assertTrue(ex.getMessage().contains("Available headers are: [id, name]."));
         }
     }
 }

--- a/core/src/test/java/org/jsmart/zerocode/core/utils/SmartUtilsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/utils/SmartUtilsTest.java
@@ -144,6 +144,14 @@ public class SmartUtilsTest {
     }
 
     @Test
+    public void testReplaceDoubleBraceTokensOrPlaceHolders() {
+        Map<String, String> paramMap = new HashMap<>();
+        paramMap.put("ENV_PROPERTY_NAME", "ci2");
+
+        assertThat(SmartUtils.resolveToken("_{{ENV_PROPERTY_NAME}}", paramMap), is("_ci2"));
+    }
+
+    @Test
     public void testEnvValue() {
 
         final String javaHomeValue = SmartUtils.getEnvPropertyValue("JAVA_HOME");

--- a/core/src/test/java/org/jsmart/zerocode/core/utils/TokenUtilsTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/core/utils/TokenUtilsTest.java
@@ -86,6 +86,21 @@ public class TokenUtilsTest {
     }
 
     @Test
+    public void testDoubleBraceTokensHaveParityAndUnknownTemplatesRemainLiteral() {
+        System.setProperty("zc.double.brace.test", "resolved-value");
+
+        String resolved = resolveKnownTokens("${SYSTEM.PROPERTY:zc.double.brace.test}|{{SYSTEM.PROPERTY:zc.double.brace.test}}|${RANDOM.NUMBER.FIXED}|{{RANDOM.NUMBER.FIXED}}");
+        String[] tokens = resolved.split("\\|");
+
+        assertThat(tokens[0], is("resolved-value"));
+        assertThat(tokens[1], is("resolved-value"));
+        assertThat(tokens[2], is(tokens[3]));
+        assertThat(resolveKnownTokens("{{localdatetime offset='-1 days'}}"), is("{{localdatetime offset='-1 days'}}"));
+
+        System.clearProperty("zc.double.brace.test");
+    }
+
+    @Test
     public void testFixedRandomGenerator_success() {
         IntStream.rangeClosed(1, 19).forEach(i -> {
             assertTrue(FixedLengthRandomGenerator.getGenerator(i).generateRandomNumber().length() == i);
@@ -194,6 +209,11 @@ public class TokenUtilsTest {
     }
 
     @Test
+    public void testGetDoubleBraceMaskedTokensReplaced(){
+        assertEquals("***masked*** and ***masked***", getMasksReplaced("{{MASKED:abc@123}} and {{MASKED:!@#$%^}}"));
+    }
+
+    @Test
     public void testGetMaskedTokensRemoved_multipleOccurrences(){
         assertEquals("This is a secret message with masked tokens.", getMasksRemoved("This is a ${MASKED:secret} message with ${MASKED:masked} tokens."));
     }
@@ -211,6 +231,11 @@ public class TokenUtilsTest {
     @Test
     public void testGetMaskedTokensRemoved_specialCharacters(){
         assertEquals("abc@123 and !@#$%^", getMasksRemoved("${MASKED:abc@123} and ${MASKED:!@#$%^}"));
+    }
+
+    @Test
+    public void testGetDoubleBraceMaskedTokensRemoved(){
+        assertEquals("abc@123 and !@#$%^", getMasksRemoved("{{MASKED:abc@123}} and {{MASKED:!@#$%^}}"));
     }
 
     @Test

--- a/core/src/test/java/org/jsmart/zerocode/integrationtests/DoubleBracePlaceholdersInMemoryTest.java
+++ b/core/src/test/java/org/jsmart/zerocode/integrationtests/DoubleBracePlaceholdersInMemoryTest.java
@@ -1,0 +1,19 @@
+package org.jsmart.zerocode.integrationtests;
+
+import org.jsmart.zerocode.core.domain.HostProperties;
+import org.jsmart.zerocode.core.domain.Scenario;
+import org.jsmart.zerocode.core.domain.TargetEnv;
+import org.jsmart.zerocode.core.tests.customrunner.TestOnlyZeroCodeUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@HostProperties(host="http://localhost", port=9998, context = "")
+@TargetEnv("dev_test.properties")
+@RunWith(TestOnlyZeroCodeUnitRunner.class)
+public class DoubleBracePlaceholdersInMemoryTest {
+
+    @Test
+    @Scenario("integration_test_files/placeholders/double_brace_placeholders_in_memory.json")
+    public void resolvesDoubleBraceAndMixedPlaceholders() throws Exception {
+    }
+}

--- a/core/src/test/resources/config_hosts_test.properties
+++ b/core/src/test/resources/config_hosts_test.properties
@@ -8,3 +8,5 @@ web.application.endpoint.context=/google-map-services
 # Placeholders resolved against system properties / OS env vars at load time
 placeholder.resolved.host=${zc.test.host}
 placeholder.unresolved.host=${zc.test.absent.host}
+placeholder.resolved.double.host={{zc.test.host}}
+placeholder.unresolved.double.host={{zc.test.absent.host}}

--- a/core/src/test/resources/integration_test_files/placeholders/double_brace_placeholders_in_memory.json
+++ b/core/src/test/resources/integration_test_files/placeholders/double_brace_placeholders_in_memory.json
@@ -1,0 +1,32 @@
+{
+  "scenarioName": "Double-brace placeholder resolution",
+  "steps": [
+    {
+      "name": "get_bathroom",
+      "url": "{{my_new_url}}/home/bathroom/{{PARAM.id}}",
+      "method": "GET",
+      "request": {
+        "headers": {
+          "X-Random": "{{RANDOM.NUMBER.FIXED}}",
+          "X-System-Property": "{{SYSTEM.PROPERTY:file.encoding}}",
+          "X-Masked": "{{MASKED:secret}}",
+          "X-Handlebars": "{{localdatetime offset='-1 days'}}"
+        }
+      },
+      "verify": {
+        "status": 200,
+        "body": {
+          "name": "${$.get_bathroom.response.body.name}",
+          "id": 1
+        }
+      }
+    }
+  ],
+  "parameterized": {
+    "withHeaders": true,
+    "csvSource": [
+      "id",
+      "1"
+    ]
+  }
+}


### PR DESCRIPTION
# Added support for {{...}} double curly braces as alternate placeholder delimiter alongside ${...}

## Fixed Which Issue?
- Fixes Issue 782 #782 

PR Branch
https://github.com/umer901/zerocode/tree/issue-782-support-double-curly-brace

## Motivation and Context

Zerocode currently supports `${...}` placeholders in test steps, target-env property files, and CSV-parameterized scenarios. This PR adds `{{...}}` as an equivalent alternative without changing existing `${...}` behavior.

Both styles can be used in the same scenario. The implementation covers known runtime tokens, system properties/environment variables, random tokens, masked values, host-property keys, JSON-path values, CSV positional/named `PARAM` values, and target-env file placeholders.

The change is intentionally scoped to existing placeholder-resolution paths and adds no dependencies.

Implementation:

* Changed the regex in ApplicationMainModule.java‎ and ZeroCodeParameterizedProcessorImpl.java‎
* Updated all comments that mention the placeholders
* Added a replaceTokens helper that passes after existing StringSubstitutor (to avoid adding the {{...}} separately at each site), and
* Updated ZeroCodeAssertionsProcessorImpl.java and SmartUtils to use the shared resolver.
* In token utils, token extraction now captures the parameter name from either bracket format. I also moved the token and masked token regexes from the function to pattern constants.

Tests:

* TokenUtilsTest.java: verifies tokens work with {{...}}, masked values work in double braces, and an unknown Handlebars-shaped token stays literal.
* ZeroCodeAssertionsProcessorImplTest.java: verified double-brace host-property resolution and mixed ${...}/{{...}} JSON-path resolution.
* ZeroCodeParameterizedProcessorImplTest.java: verified double-brace positional and named CSV parameters, plus the missing-header error path.
* ApplicationMainModuleTest.java: verified target-env properties resolve from both delimiter styles and unresolved values remain unchanged.
* SmartUtilsTest.java: verified generic map-based replacement works with double braces.
* Added integration coverage in DoubleBracePlaceholdersInMemoryTest.java which starts the in-memory simulator and executes a real HTTP scenario using {{...}} host-property, CSV PARAM, random, system-property, and masked tokens. It also mixes ${...} and {{...}} in the same scenario and confirms the Handlebars-shaped header remains literal.

## Checklist:

* [X] 1. New Unit tests were added
  * [ ] 1.1 Covered in existing Unit tests

* [x] 2. Integration tests were added
  * [ ] 2.1 Covered in existing Integration tests

* [x] 3. Test names are meaningful

* [x] 3.1 Feature manually tested and outcome is successful

* [x] 4. PR doesn't break any of the earlier features for end users
  * [ ] 4.1 WARNING! This might break one or more earlier earlier features, hence left a comment tagging all reviewrs

* [X] 5. PR doesn't break the HTML report features directly
  * [X] 5.1 Yes! I've manually run it locally and seen the HTML reports are generated perfectly fine
  * [X] 5.2 Yes! I've opened the generated HTML reports from the `/target` folder and they look fine

* [x] 6. PR doesn't break any HTML report features indirectly
  * [X] 6.1 I have not added or amended any dependencies in this PR
  * [ ] 6.2 I have double checked, the new dependency added or removed has not affected the report generation indirectly
  * [x] 6.3 Yes! I've seen the Sample report screenshots [here](https://github.com/authorjapps/zerocode/issues/694#issuecomment-2505958433), and HTML report of the current PR looks simillar.

* [x] 7. Branch build passed in CI

* [ ] 8. No 'package.*' in the imports


* [x] 9. Relevant DOcumentation page added or updated with clear instructions and examples for the end user
  * [ ] 9.1 Not applicable. This was only a code refactor change, no functional or behaviourial changes were introduced
* [ ] 10. Http test added to `http-testing-examples` module(if applicable) ?
  * [X] 10.1 Not applicable. The changes did not affect HTTP automation flow

* [ ] 11. Kafka test added to `kafka-testing-examples` module(if applicable) ?
  * [X] 11.1 Not applicable. The changes did not affect Kafka automation flow

I have one question, is there a need to add documentation, and if so where? I reflected the changes in the comments where needed.